### PR TITLE
Add Help tab to settings window & Improve workflow

### DIFF
--- a/DesktopClock/Data/TeachingTips.cs
+++ b/DesktopClock/Data/TeachingTips.cs
@@ -7,6 +7,7 @@ public enum TeachingTips
 {
     None = 0,
 
+    [Obsolete("Always asks now")]
     NewClock = 1 << 0,
 
     [Obsolete("Settings were moved to a native window")]

--- a/DesktopClock/Data/TeachingTips.cs
+++ b/DesktopClock/Data/TeachingTips.cs
@@ -6,8 +6,14 @@ namespace DesktopClock;
 public enum TeachingTips
 {
     None = 0,
+
     NewClock = 1 << 0,
+
+    [Obsolete("Settings were moved to a native window")]
     AdvancedSettings = 1 << 1,
+
     HideForNow = 1 << 2,
+
+    [Obsolete("Moved to Help which and is clearly visible as a link")]
     CheckForUpdates = 1 << 3,
 }

--- a/DesktopClock/DesktopClock.csproj
+++ b/DesktopClock/DesktopClock.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <Company>Daniel Chalmers</Company>
-    <Description>A digital clock app for your Windows desktop that stays on screen, ready whenever you need it.</Description>
+    <Description>A digital clock for your desktop that stays on screen, ready whenever you need it.</Description>
     <Copyright>© Daniel Chalmers</Copyright>
     <Version>4.1.0</Version>
   </PropertyGroup>

--- a/DesktopClock/MainWindow.xaml
+++ b/DesktopClock/MainWindow.xaml
@@ -30,6 +30,8 @@
             <MenuItem Command="{Binding CopyToClipboardCommand}" Header="_Copy" />
 
             <MenuItem Command="{Binding HideForNowCommand}" Header="_Hide for now" />
+            
+            <MenuItem Command="{Binding OpenSettingsCommand}" Header="_Settings &amp; help" />
 
             <Separator />
 
@@ -64,13 +66,9 @@
 
             <Separator />
 
-            <MenuItem Command="{Binding OpenSettingsCommand}" Header="_Settings" />
-
             <MenuItem Command="{Binding NewClockCommand}"
-                      Header="_New clock"
+                      Header="Create _new clock"
                       IsEnabled="{x:Static p:Settings.CanBeSaved}" />
-
-            <MenuItem Command="{Binding CheckForUpdatesCommand}" Header="Check for _updates" />
 
             <MenuItem Command="{Binding ExitCommand}" Header="E_xit" />
         </ContextMenu>

--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -108,46 +108,19 @@ public partial class MainWindow : Window
     [RelayCommand]
     public void NewClock()
     {
-        if (!Settings.Default.TipsShown.HasFlag(TeachingTips.NewClock))
-        {
-            var result = MessageBox.Show(this,
-                "This will copy the executable and start it with new settings.\n\n" +
-                "Continue?",
-                Title, MessageBoxButton.OKCancel, MessageBoxImage.Question, MessageBoxResult.OK);
+        var result = MessageBox.Show(this,
+            "This will copy the executable and start it with new settings.\n\n" +
+            "Continue?",
+            Title, MessageBoxButton.OKCancel, MessageBoxImage.Question, MessageBoxResult.OK);
 
-            if (result != MessageBoxResult.OK)
-                return;
-
-            Settings.Default.TipsShown |= TeachingTips.NewClock;
-        }
+        if (result != MessageBoxResult.OK)
+            return;
 
         var newExePath = Path.Combine(App.MainFileInfo.DirectoryName, App.MainFileInfo.GetFileAtNextIndex().Name);
 
         // Copy and start the new clock.
         File.Copy(App.MainFileInfo.FullName, newExePath);
         Process.Start(newExePath);
-    }
-
-    /// <summary>
-    /// Opens the GitHub Releases page.
-    /// </summary>
-    [RelayCommand]
-    public void CheckForUpdates()
-    {
-        if (!Settings.Default.TipsShown.HasFlag(TeachingTips.CheckForUpdates))
-        {
-            var result = MessageBox.Show(this,
-                "This will take you to GitHub to view the latest releases.\n\n" +
-                "Continue?",
-                Title, MessageBoxButton.OKCancel, MessageBoxImage.Question, MessageBoxResult.OK);
-
-            if (result != MessageBoxResult.OK)
-                return;
-
-            Settings.Default.TipsShown |= TeachingTips.CheckForUpdates;
-        }
-
-        Process.Start("https://github.com/danielchalmers/DesktopClock/releases");
     }
 
     /// <summary>

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -199,5 +199,96 @@
                            Margin="0,0,0,12" />
             </StackPanel>
         </TabItem>
+
+        <TabItem Header="Help">
+            <StackPanel>
+                <TextBlock FontWeight="Bold" FontSize="16">Shortcuts</TextBlock>
+                <StackPanel Margin="0,0,0,12">
+                    <TextBlock>
+                        <Run FontWeight="Bold">Right-click:</Run>
+                        Open the context menu</TextBlock>
+                    <TextBlock>
+                        <Run FontWeight="Bold">Double-click:</Run>
+                        Copy clock text to clipboard</TextBlock>
+                    <TextBlock>
+                        <Run FontWeight="Bold">Ctrl and Mouse Wheel:</Run>
+                        Zoom</TextBlock>
+                    <TextBlock>
+                        <Run FontWeight="Bold">Ctrl and +:</Run>
+                        Zoom in</TextBlock>
+                    <TextBlock>
+                        <Run FontWeight="Bold">Ctrl and -:</Run>
+                        Zoom out</TextBlock>
+                </StackPanel>
+
+                <TextBlock FontWeight="Bold" FontSize="16">Links</TextBlock>
+                <StackPanel Margin="0,0,0,12">
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/danielchalmers/DesktopClock/releases" RequestNavigate="Hyperlink_RequestNavigate">
+                            GitHub Releases (Check for updates)
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/danielchalmers/DesktopClock/issues" RequestNavigate="Hyperlink_RequestNavigate">
+                            GitHub Issues (Found a bug or have an idea?)
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/danielchalmers/JournalApp" RequestNavigate="Hyperlink_RequestNavigate">
+                            JournalApp - Write notes and keep track of your day (Android).
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/danielchalmers/Network-Monitor" RequestNavigate="Hyperlink_RequestNavigate">
+                            Network Monitor - View latency and bandwidth usage (Windows).
+                        </Hyperlink>
+                    </TextBlock>
+                </StackPanel>
+
+                <TextBlock FontWeight="Bold" FontSize="16">Credits</TextBlock>
+                <StackPanel Margin="0,0,0,12">
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/CommunityToolkit/dotnet" RequestNavigate="Hyperlink_RequestNavigate">
+                            CommunityToolkit
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/Fody/Costura" RequestNavigate="Hyperlink_RequestNavigate">
+                            Costura.Fody
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/HavenDV/H.NotifyIcon" RequestNavigate="Hyperlink_RequestNavigate">
+                            H.NotifyIcon.Wpf
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/Humanizr/Humanizer" RequestNavigate="Hyperlink_RequestNavigate">
+                            Humanizer
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://www.newtonsoft.com/json" RequestNavigate="Hyperlink_RequestNavigate">
+                            Newtonsoft.Json
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/Fody/PropertyChanged" RequestNavigate="Hyperlink_RequestNavigate">
+                            PropertyChanged.Fody
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://github.com/danielchalmers/WpfWindowPlacement" RequestNavigate="Hyperlink_RequestNavigate">
+                            WpfWindowPlacement
+                        </Hyperlink>
+                    </TextBlock>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://www.flaticon.com/free-icon/three-o-clock-clock_13435" RequestNavigate="Hyperlink_RequestNavigate">
+                            Clock icon
+                        </Hyperlink>
+                    </TextBlock>
+                </StackPanel>
+            </StackPanel>
+        </TabItem>
     </TabControl>
 </Window>

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -235,12 +235,12 @@
                     </TextBlock>
                     <TextBlock>
                         <Hyperlink NavigateUri="https://github.com/danielchalmers/JournalApp" RequestNavigate="Hyperlink_RequestNavigate">
-                            JournalApp - Write notes and keep track of your day (Android).
+                            JournalApp - Save notes and keep track of your well-being (Android)
                         </Hyperlink>
                     </TextBlock>
                     <TextBlock>
                         <Hyperlink NavigateUri="https://github.com/danielchalmers/Network-Monitor" RequestNavigate="Hyperlink_RequestNavigate">
-                            Network Monitor - View latency and bandwidth usage (Windows).
+                            Network Monitor - View live latency and bandwidth usage (Windows)
                         </Hyperlink>
                     </TextBlock>
                 </StackPanel>

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -237,7 +237,7 @@
                         </Hyperlink>
                     </TextBlock>
                     <TextBlock>
-                        <Hyperlink NavigateUri="https://github.com/danielchalmers/JournalApp" RequestNavigate="Hyperlink_RequestNavigate">
+                        <Hyperlink NavigateUri="https://play.google.com/store/apps/details?id=com.danielchalmers.journalapp" RequestNavigate="Hyperlink_RequestNavigate">
                             JournalApp - Save notes and keep track of your well-being (Android)
                         </Hyperlink>
                     </TextBlock>

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -8,7 +8,7 @@
         d:DataContext="{d:DesignInstance Type=local:SettingsWindowViewModel}"
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
         mc:Ignorable="d"
-        Title="DesktopClock Settings"
+        Title="DesktopClock"
         Width="500"
         ResizeMode="CanMinimize"
         SizeToContent="Height"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -211,6 +211,9 @@
                         <Run FontWeight="Bold">Double-click:</Run>
                         Copy clock text to clipboard</TextBlock>
                     <TextBlock>
+                        <Run FontWeight="Bold">Click and drag:</Run>
+                        Move the window</TextBlock>
+                    <TextBlock>
                         <Run FontWeight="Bold">Ctrl and Mouse Wheel:</Run>
                         Zoom</TextBlock>
                     <TextBlock>

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Navigation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DesktopClock.Properties;
@@ -61,6 +63,12 @@ public partial class SettingsWindow : Window
         }
 
         ViewModel.Settings.WavFilePath = openFileDialog.FileName;
+    }
+
+    private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+        e.Handled = true;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,7 @@
 [![Release](https://img.shields.io/github/release/danielchalmers/DesktopClock?include_prereleases)](https://github.com/danielchalmers/DesktopClock/releases)
 [![License](https://img.shields.io/github/license/danielchalmers/DesktopClock)](LICENSE)
 
-A digital clock app for your Windows desktop that stays on screen, ready whenever you need it.
-
-- Right-click to access essential options like size, time zone, format, and theme, or to create new clocks.
-- Double-click to copy the time to your clipboard, and scroll while holding Ctrl to resize the clock.
-- "Advanced settings" provides additional configuration options using JSON format.
-- Includes a countdown mode to set a timer for any specific date.
+A digital clock for your desktop that stays on screen, ready whenever you need it.
 
 **Main window:**  
 ![Animation](https://github.com/danielchalmers/DesktopClock/assets/7112040/6038fa47-3a29-4b74-8f4f-fffeb8af8d0a)  
@@ -20,23 +15,12 @@ A digital clock app for your Windows desktop that stays on screen, ready wheneve
 
 Explore my other free apps:
 
-😊[JournalApp](https://github.com/danielchalmers/JournalApp) - Write notes & keep track of your mood, medications, and more with a versatile journaling app for Android!
+😊[JournalApp](https://github.com/danielchalmers/JournalApp) - Stay on top of your well-being with a versatile journaling app for Android!
 
-🔄[Network Monitor](https://github.com/danielchalmers/Network-Monitor) - View live network latency and bandwidth usage on your desktop with a widget like the clock.
+🔄[Network Monitor](https://github.com/danielchalmers/Network-Monitor) - View live network latency and bandwidth usage on your desktop.
 
 ## Contributions
 
 Got an idea or found a bug? Submit an [issue](https://github.com/danielchalmers/DesktopClock/issues)!
 
-If you are gracious enough to contribute code, please try to align with the current formatting and keep features simple as possible.
-
-## Credits
-
-- [CommunityToolkit](https://github.com/CommunityToolkit/dotnet)
-- [Costura.Fody](https://github.com/Fody/Costura)
-- [H.NotifyIcon.Wpf](https://github.com/HavenDV/H.NotifyIcon)
-- [Humanizer](https://github.com/Humanizr/Humanizer)
-- [Newtonsoft.Json](https://www.newtonsoft.com/json)
-- [PropertyChanged.Fody](https://github.com/Fody/PropertyChanged)
-- [WpfWindowPlacement](https://github.com/danielchalmers/WpfWindowPlacement)
-- [Clock icon](https://www.flaticon.com/free-icon/three-o-clock-clock_13435)
+Contributions are welcome! Please try to align with the current formatting and keep features simple if possible.


### PR DESCRIPTION
We now have a very flexible window with tabs that can contain a ton of different things. With this PR I'm adding a Help tab that contains shortcut tips, related links, and credits.

![image](https://github.com/user-attachments/assets/b3f8ab29-5ecd-443d-adbb-31b597d01f1b)

Context menu was tweaked:

![image](https://github.com/user-attachments/assets/3263131d-e024-4866-8983-89c848ff43df)

