### PR TITLE
Show error instead of falling back to default format

### DIFF
--- a/DesktopClock.Tests/TimeStringFormatterTests.cs
+++ b/DesktopClock.Tests/TimeStringFormatterTests.cs
@@ -132,4 +132,39 @@ public class TimeStringFormatterTests
 
         Assert.Equal("18:30", result);
     }
+
+    [Fact]
+    public void Format_InvalidClockFormatShowsBriefErrorMessage()
+    {
+        var now = new DateTimeOffset(2024, 1, 1, 10, 15, 0, TimeSpan.Zero);
+
+        var result = TimeStringFormatter.Format(
+            now,
+            now.DateTime,
+            TimeZoneInfo.Utc,
+            default,
+            "{Q}",
+            null,
+            CultureInfo.InvariantCulture);
+
+        Assert.Equal(Tokenizer.FormatErrorMessage, result);
+    }
+
+    [Fact]
+    public void Format_InvalidCountdownFormatShowsBriefErrorMessage()
+    {
+        var now = new DateTimeOffset(2024, 1, 1, 10, 0, 0, TimeSpan.Zero);
+        var nowDateTime = now.DateTime;
+
+        var result = TimeStringFormatter.Format(
+            now,
+            nowDateTime,
+            TimeZoneInfo.Utc,
+            nowDateTime.AddMinutes(30),
+            "HH:mm",
+            "{bad}",
+            CultureInfo.InvariantCulture);
+
+        Assert.Equal(Tokenizer.FormatErrorMessage, result);
+    }
 }

--- a/DesktopClock.Tests/TokenizerTests.cs
+++ b/DesktopClock.Tests/TokenizerTests.cs
@@ -140,32 +140,34 @@ public class TokenizerTests
     }
 
     [Fact]
-    public void FormatWithTokenizer_InvalidFormat_ShouldNotThrow()
+    public void FormatWithTokenizer_InvalidFormat_ShouldReturnErrorMessage()
     {
         // Arrange
         var dateTime = new DateTime(2023, 09, 24, 12, 13, 14);
-        var format = "{invalid-format-string-xyz}";
-
-        // Act - should not throw, may produce unexpected output but should handle gracefully
-        var result = Tokenizer.FormatWithTokenizerOrFallBack(dateTime, format, CultureInfo.InvariantCulture);
-
-        // Assert - just verify it returns something and doesn't throw
-        Assert.NotNull(result);
-    }
-
-    [Fact]
-    public void FormatWithTokenizer_EmptyTokens_ShouldHandleGracefully()
-    {
-        // Arrange
-        var dateTime = new DateTime(2023, 09, 24, 12, 13, 14);
-        var format = "{}";
+        var format = "{Q}";
 
         // Act
         var result = Tokenizer.FormatWithTokenizerOrFallBack(dateTime, format, CultureInfo.InvariantCulture);
 
         // Assert
-        // Empty braces should be handled
-        Assert.NotNull(result);
+        Assert.Equal(Tokenizer.FormatErrorMessage, result);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{HH:mm")]
+    [InlineData("HH:mm}")]
+    [InlineData("{{HH:mm}}")]
+    public void FormatWithTokenizer_BrokenTokenSyntax_ShouldReturnErrorMessage(string format)
+    {
+        // Arrange
+        var dateTime = new DateTime(2023, 09, 24, 12, 13, 14);
+
+        // Act
+        var result = Tokenizer.FormatWithTokenizerOrFallBack(dateTime, format, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal(Tokenizer.FormatErrorMessage, result);
     }
 
     [Theory]

--- a/DesktopClock/Utilities/Tokenizer.cs
+++ b/DesktopClock/Utilities/Tokenizer.cs
@@ -6,10 +6,11 @@ namespace DesktopClock;
 public static class Tokenizer
 {
     private static readonly Regex _tokenizerRegex = new("{([^{}]+)}", RegexOptions.Compiled);
+    public const string FormatErrorMessage = "Bad format";
 
     /// <summary>
     /// <para>Returns a string formatted using a tokenized format or the default formatting method.</para>
-    /// <para>Falls back to the default format on any exception.</para>
+    /// <para>Returns a short error message when a non-empty format is malformed.</para>
     /// </summary>
     /// <param name="formattable">The object to format.</param>
     /// <param name="format">The format to use.</param>
@@ -20,11 +21,16 @@ public static class Tokenizer
         {
             try
             {
-                if (format.Contains("}"))
+                if (UsesTokenSyntax(format))
                 {
+                    if (!HasValidTokenSyntax(format))
+                    {
+                        return FormatErrorMessage;
+                    }
+
                     return _tokenizerRegex.Replace(format, (m) =>
                     {
-                        var formatString = m.Value.Replace("{", "").Replace("}", "");
+                        var formatString = m.Groups[1].Value;
                         return formattable.ToString(formatString, formatProvider);
                     });
                 }
@@ -34,10 +40,49 @@ public static class Tokenizer
             }
             catch
             {
+                return FormatErrorMessage;
             }
         }
 
         // Fall back to the default format.
         return formattable.ToString();
+    }
+
+    private static bool UsesTokenSyntax(string format)
+    {
+        return format.Contains("{") || format.Contains("}");
+    }
+
+    private static bool HasValidTokenSyntax(string format)
+    {
+        var index = 0;
+        while (index < format.Length)
+        {
+            if (format[index] == '}')
+            {
+                return false;
+            }
+
+            if (format[index] != '{')
+            {
+                index++;
+                continue;
+            }
+
+            var closeIndex = format.IndexOf('}', index + 1);
+            if (closeIndex == -1 || closeIndex == index + 1)
+            {
+                return false;
+            }
+
+            if (format.IndexOf('{', index + 1, closeIndex - index - 1) != -1)
+            {
+                return false;
+            }
+
+            index = closeIndex + 1;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Invalid or malformed formats now show `Bad format` instead of falling back to the default string, while blank formats still keep the existing default behavior.

<img width="1010" height="742" alt="image" src="https://github.com/user-attachments/assets/a0292215-727e-4465-850e-ca3b89f40212" />

