### PR TITLE
Split release packaging by architecture

### DIFF
--- a/.github/actions/create-release-artifacts/action.yml
+++ b/.github/actions/create-release-artifacts/action.yml
@@ -6,31 +6,35 @@ inputs:
   version:
     description: 'Version number for the app'
     default: '0.0.0'
-  archs:
-    description: 'Architectures for the build'
-    default: 'x64 arm64'
+  arch:
+    description: 'Architecture for the build'
+    default: 'x64'
+  artifact-name:
+    description: 'Name for the uploaded artifact bundle'
+    default: 'desktopclock'
 
 runs:
   using: "composite"
   steps:
+    - uses: actions/setup-dotnet@v4
+
     - name: Create Binaries
       shell: bash
       run: |
+        arch="${{ inputs.arch }}"
         dotnet tool install --global wix --version 4.0.6
-        for arch in ${{ inputs.archs }}; do
-          dotnet publish ./DesktopClock/DesktopClock.csproj -o "publish/$arch" -c Release --os win --arch $arch -p:Version=${{ inputs.version }}
-          wix build Product.wxs -d MainExeSource="publish/$arch/DesktopClock.exe" -o "publish/DesktopClock-${{ inputs.version }}-${arch}.msi"
-        done
+        dotnet publish ./DesktopClock/DesktopClock.csproj -o "publish/$arch" -c Release --os win --arch "$arch" -p:Version=${{ inputs.version }}
+        wix build Product.wxs -d MainExeSource="publish/$arch/DesktopClock.exe" -o "publish/DesktopClock-${{ inputs.version }}-$arch.msi"
 
-    - name: Create Portable ZIPs
+    - name: Create Portable ZIP
       shell: pwsh
       run: |
-        foreach ($arch in "${{ inputs.archs }}".Split(' ')) {
-          Compress-Archive -Path "publish/$arch/DesktopClock.exe" -DestinationPath "publish/DesktopClock-${{ inputs.version }}-$arch.zip"
-        }
+        $arch = "${{ inputs.arch }}"
+        Compress-Archive -Path "publish/$arch/DesktopClock.exe" -DestinationPath "publish/DesktopClock-${{ inputs.version }}-$arch.zip"
 
     - uses: actions/upload-artifact@v4
       with:
+        name: ${{ inputs.artifact-name }}
         if-no-files-found: error
         path: |
           publish/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,30 @@ on:
     branches: [ master ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  build:
+  build-test:
+    name: Build and Test
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/build-and-test
+
+  package:
+    name: Package (${{ matrix.arch }})
+    needs: build-test
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/create-release-artifacts
+        with:
+          arch: ${{ matrix.arch }}
+          artifact-name: desktopclock-${{ matrix.arch }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,23 +12,51 @@ on:
         required: true
         default: 'false'
 
+permissions:
+  contents: write
+
 jobs:
-  deploy:
+  build-test:
+    name: Build and Test
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
 
     - uses: ./.github/actions/build-and-test
 
+  package:
+    name: Package (${{ matrix.arch }})
+    needs: build-test
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    steps:
+    - uses: actions/checkout@v4
+
     - uses: ./.github/actions/create-release-artifacts
       with:
         version: ${{ github.event.inputs.version }}
+        arch: ${{ matrix.arch }}
+        artifact-name: desktopclock-${{ matrix.arch }}
+
+  deploy:
+    name: Create GitHub release
+    needs: package
+    runs-on: windows-latest
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: desktopclock-*
+        path: release-artifacts
+        merge-multiple: true
 
     - name: Create GitHub release
       uses: ncipollo/release-action@v1
       with:
         tag: "v${{ github.event.inputs.version }}"
-        artifacts: "publish/*.zip,publish/*.msi"
+        artifacts: "release-artifacts/*.zip,release-artifacts/*.msi"
         generateReleaseNotes: true
         prerelease: ${{ contains(github.event.inputs.version, 'preview') }}
         allowUpdates: ${{ github.event.inputs.updateRelease }}


### PR DESCRIPTION
Description: Reworks CI and release workflows so packaging runs separately for `x64` and `arm64` using a matrix.

Summary:
- Add parallel package jobs for `x64` and `arm64`
- Build/test once before packaging
- Upload architecture-specific artifacts
- Download matrix artifacts before creating a release
- Replace the old multi-architecture loop with a single `arch` input
- Clean up stale portable ZIP step naming

Closes #111 as a replacement