### PR TITLE
Add navigation sidebar to settings window

### DIFF
--- a/DesktopClock/Properties/Settings.cs
+++ b/DesktopClock/Properties/Settings.cs
@@ -347,7 +347,7 @@ public sealed class Settings : INotifyPropertyChanged, IDisposable
     /// <remarks>
     /// This remembers how wide you last made the settings window so it feels familiar the next time you open it.
     /// </remarks>
-    public double SettingsWindowWidth { get; set; } = 720;
+    public double SettingsWindowWidth { get; set; } = 1200;
 
     /// <summary>
     /// Persisted height of the settings window.
@@ -355,7 +355,7 @@ public sealed class Settings : INotifyPropertyChanged, IDisposable
     /// <remarks>
     /// This remembers how tall you last made the settings window so you do not have to resize it every time.
     /// </remarks>
-    public double SettingsWindowHeight { get; set; } = 600;
+    public double SettingsWindowHeight { get; set; } = 900;
 
     /// <summary>
     /// Persisted vertical scroll offset of the settings window.

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -136,6 +136,16 @@
                 </Grid.RowDefinitions>
 
                 <StackPanel Grid.Row="0">
+                    <TextBlock Text="DesktopClock"
+                               FontSize="20"
+                               FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding AppVersion, StringFormat=v{0}}"
+                               Foreground="#5B6F8E"
+                               Margin="0,0,0,22" />
+                </StackPanel>
+
+                <StackPanel Grid.Row="1"
+                            VerticalAlignment="Center">
                     <Button Content="_Display"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=DisplaySection}"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -26,10 +26,9 @@
                TargetType="Button"
                BasedOn="{StaticResource {x:Type Button}}">
             <Setter Property="HorizontalContentAlignment" Value="Left" />
-            <Setter Property="Background" Value="#FFFFFF" />
-            <Setter Property="BorderBrush" Value="#DADDE3" />
-            <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="Margin" Value="0,0,0,4" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Margin" Value="0,0,0,2" />
             <Setter Property="Padding" Value="8,8,24,8" />
             <Setter Property="MinHeight" Value="40" />
         </Style>
@@ -37,6 +36,9 @@
         <Style x:Key="SidebarToolButton"
                TargetType="Button"
                BasedOn="{StaticResource SidebarButton}">
+            <Setter Property="Background" Value="#FFFFFF" />
+            <Setter Property="BorderBrush" Value="#DADDE3" />
+            <Setter Property="BorderThickness" Value="1" />
             <Setter Property="Padding" Value="8,7,24,7" />
             <Setter Property="MinWidth" Value="150" />
             <Setter Property="MinHeight" Value="0" />

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -115,35 +115,35 @@
                                Foreground="#5B6F8E"
                                Margin="0,0,0,22" />
 
-                    <Button Content="Display"
+                    <Button Content="_Display"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=DisplaySection}"
                             Click="NavigateToSection" />
-                    <Button Content="Countdown"
+                    <Button Content="_Countdown"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=CountdownSection}"
                             Click="NavigateToSection" />
-                    <Button Content="Window"
+                    <Button Content="_Window"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=WindowSection}"
                             Click="NavigateToSection" />
-                    <Button Content="Typography"
+                    <Button Content="_Typography"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=TypographySection}"
                             Click="NavigateToSection" />
-                    <Button Content="Appearance"
+                    <Button Content="A_ppearance"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=AppearanceSection}"
                             Click="NavigateToSection" />
-                    <Button Content="Alerts"
+                    <Button Content="_Alerts"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=AlertsSection}"
                             Click="NavigateToSection" />
-                    <Button Content="Tools"
+                    <Button Content="T_ools"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=ToolsSection}"
                             Click="NavigateToSection" />
-                    <Button Content="Shortcuts"
+                    <Button Content="_Shortcuts"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=ShortcutsSection}"
                             Click="NavigateToSection" />
@@ -151,10 +151,10 @@
 
                 <StackPanel DockPanel.Dock="Bottom"
                             VerticalAlignment="Bottom">
-                    <Button Content="Settings folder"
+                    <Button Content="Settings _folder"
                             Click="OpenSettingsFolder"
                             IsEnabled="{x:Static p:Settings.CanBeSaved}" />
-                    <Button Content="New clock"
+                    <Button Content="_New clock"
                             Background="#256BEF"
                             BorderBrush="#256BEF"
                             Foreground="White"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -29,8 +29,8 @@
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Margin" Value="0,0,0,2" />
-            <Setter Property="Padding" Value="8,8,24,8" />
-            <Setter Property="MinHeight" Value="40" />
+            <Setter Property="Padding" Value="8,6,24,6" />
+            <Setter Property="MinHeight" Value="34" />
         </Style>
 
         <Style x:Key="SidebarToolButton"
@@ -39,10 +39,10 @@
             <Setter Property="Background" Value="#FFFFFF" />
             <Setter Property="BorderBrush" Value="#DADDE3" />
             <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="Padding" Value="8,7,24,7" />
+            <Setter Property="Padding" Value="8,5,24,5" />
             <Setter Property="MinWidth" Value="150" />
             <Setter Property="MinHeight" Value="0" />
-            <Setter Property="Margin" Value="0,0,0,4" />
+            <Setter Property="Margin" Value="0,0,0,3" />
         </Style>
 
         <Style x:Key="SidebarToolDescription"
@@ -51,7 +51,7 @@
             <Setter Property="FontWeight" Value="Normal" />
             <Setter Property="TextWrapping" Value="Wrap" />
             <Setter Property="Opacity" Value="0.75" />
-            <Setter Property="Margin" Value="0,2,0,0" />
+            <Setter Property="Margin" Value="0,1,0,0" />
         </Style>
 
         <Style x:Key="ColorSwatchButton"
@@ -128,7 +128,7 @@
                 Background="#FAFAFA"
                 BorderBrush="#E1E4E8"
                 BorderThickness="0,0,1,0">
-            <Grid Margin="8,18,8,16">
+            <Grid Margin="8,10,8,8">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
@@ -136,13 +136,13 @@
                 </Grid.RowDefinitions>
 
                 <StackPanel Grid.Row="0"
-                            Margin="8,0,24,0">
+                            Margin="8,0,24,6">
                     <TextBlock Text="DesktopClock"
                                FontSize="20"
                                FontWeight="SemiBold" />
                     <TextBlock Text="{Binding AppVersion, StringFormat=v{0}}"
                                Foreground="#5B6F8E"
-                               Margin="0,0,0,22" />
+                               Margin="0,0,0,8" />
                 </StackPanel>
 
                 <StackPanel Grid.Row="1"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -135,8 +135,7 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <StackPanel Grid.Row="0"
-                            HorizontalAlignment="Center">
+                <StackPanel Grid.Row="0">
                     <TextBlock Text="DesktopClock"
                                FontSize="20"
                                FontWeight="SemiBold" />

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -66,6 +66,7 @@
         <Style x:Key="CardGroupBox"
                TargetType="GroupBox">
             <Setter Property="Margin" Value="0,0,0,16" />
+            <Setter Property="Focusable" Value="True" />
         </Style>
 
         <Style x:Key="CardBodyPanel"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -135,7 +135,8 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <StackPanel Grid.Row="0">
+                <StackPanel Grid.Row="0"
+                            HorizontalAlignment="Center">
                     <TextBlock Text="DesktopClock"
                                FontSize="20"
                                FontWeight="SemiBold" />

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -108,7 +108,13 @@
                 BorderBrush="#E1E4E8"
                 BorderThickness="0,0,1,0">
             <Grid Margin="8,18,8,16">
-                <StackPanel VerticalAlignment="Center">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <StackPanel Grid.Row="0">
                     <Button Content="_Display"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=DisplaySection}"
@@ -133,10 +139,6 @@
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=AlertsSection}"
                             Click="NavigateToSection" />
-                    <Button Content="T_ools"
-                            Style="{StaticResource SidebarButton}"
-                            Tag="{Binding ElementName=ToolsSection}"
-                            Click="NavigateToSection" />
                     <Button Content="_Shortcuts"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=ShortcutsSection}"
@@ -149,6 +151,21 @@
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=CreditsSection}"
                             Click="NavigateToSection" />
+                </StackPanel>
+
+                <StackPanel Grid.Row="2">
+                    <Button Content="Settings _folder"
+                            Click="OpenSettingsFolder"
+                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
+                    <Button Content="Settings f_ile"
+                            Click="OpenSettingsFile"
+                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
+                    <Button Content="_New clock"
+                            Background="#256BEF"
+                            BorderBrush="#256BEF"
+                            Foreground="White"
+                            Click="CreateNewClock"
+                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
                 </StackPanel>
             </Grid>
         </Border>
@@ -578,32 +595,6 @@
                     <CheckBox Content="Play sound when countdown ends"
                               IsChecked="{Binding Settings.PlaySoundOnCountdown, Mode=TwoWay}" />
                     <TextBlock Text="Play the selected sound when the countdown finishes."
-                               Style="{StaticResource DescriptionTextBlock}" />
-                </StackPanel>
-            </GroupBox>
-
-            <GroupBox x:Name="ToolsSection"
-                      Header="Tools"
-                      Style="{StaticResource CardGroupBox}">
-                <StackPanel Style="{StaticResource CardBodyPanel}">
-                    <Button Content="Open settings folder"
-                            Click="OpenSettingsFolder"
-                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
-                    <TextBlock Text="Open the folder where the settings file is stored."
-                               Margin="0,0,0,16"
-                               Style="{StaticResource DescriptionTextBlock}" />
-
-                    <Button Content="Open settings file"
-                            Click="OpenSettingsFile"
-                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
-                    <TextBlock Text="Open the JSON settings file in Notepad."
-                               Margin="0,0,0,16"
-                               Style="{StaticResource DescriptionTextBlock}" />
-
-                    <Button Content="Create new clock"
-                            Click="CreateNewClock"
-                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
-                    <TextBlock Text="Copy this clock and start it with fresh settings."
                                Style="{StaticResource DescriptionTextBlock}" />
                 </StackPanel>
             </GroupBox>

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -33,6 +33,24 @@
             <Setter Property="MinHeight" Value="40" />
         </Style>
 
+        <Style x:Key="SidebarToolButton"
+               TargetType="Button"
+               BasedOn="{StaticResource {x:Type Button}}">
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="Padding" Value="8,6" />
+            <Setter Property="MinWidth" Value="150" />
+            <Setter Property="Margin" Value="0,0,0,6" />
+        </Style>
+
+        <Style x:Key="SidebarToolDescription"
+               TargetType="TextBlock">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="FontWeight" Value="Normal" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="Opacity" Value="0.75" />
+            <Setter Property="Margin" Value="0,2,0,0" />
+        </Style>
+
         <Style x:Key="ColorSwatchButton"
                TargetType="Button"
                BasedOn="{StaticResource {x:Type Button}}">
@@ -154,18 +172,39 @@
                 </StackPanel>
 
                 <StackPanel Grid.Row="2">
-                    <Button Content="Settings _folder"
+                    <Button Style="{StaticResource SidebarToolButton}"
                             Click="OpenSettingsFolder"
-                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
-                    <Button Content="Settings f_ile"
+                            IsEnabled="{x:Static p:Settings.CanBeSaved}">
+                        <StackPanel>
+                            <AccessText FontWeight="SemiBold"
+                                        Text="Settings _folder" />
+                            <TextBlock Text="Open the settings folder."
+                                       Style="{StaticResource SidebarToolDescription}" />
+                        </StackPanel>
+                    </Button>
+                    <Button Style="{StaticResource SidebarToolButton}"
                             Click="OpenSettingsFile"
-                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
-                    <Button Content="_New clock"
+                            IsEnabled="{x:Static p:Settings.CanBeSaved}">
+                        <StackPanel>
+                            <AccessText FontWeight="SemiBold"
+                                        Text="Settings f_ile" />
+                            <TextBlock Text="Open the JSON file."
+                                       Style="{StaticResource SidebarToolDescription}" />
+                        </StackPanel>
+                    </Button>
+                    <Button Style="{StaticResource SidebarToolButton}"
                             Background="#256BEF"
                             BorderBrush="#256BEF"
                             Foreground="White"
                             Click="CreateNewClock"
-                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
+                            IsEnabled="{x:Static p:Settings.CanBeSaved}">
+                        <StackPanel>
+                            <AccessText FontWeight="SemiBold"
+                                        Text="_New clock" />
+                            <TextBlock Text="Start a fresh copy."
+                                       Style="{StaticResource SidebarToolDescription}" />
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
             </Grid>
         </Border>

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -26,9 +26,10 @@
                TargetType="Button"
                BasedOn="{StaticResource {x:Type Button}}">
             <Setter Property="HorizontalContentAlignment" Value="Left" />
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Margin" Value="0,0,0,2" />
+            <Setter Property="Background" Value="#FFFFFF" />
+            <Setter Property="BorderBrush" Value="#DADDE3" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Margin" Value="0,0,0,4" />
             <Setter Property="Padding" Value="8,8,24,8" />
             <Setter Property="MinHeight" Value="40" />
         </Style>
@@ -39,7 +40,7 @@
             <Setter Property="Padding" Value="8,7,24,7" />
             <Setter Property="MinWidth" Value="150" />
             <Setter Property="MinHeight" Value="0" />
-            <Setter Property="Margin" Value="0,0,0,2" />
+            <Setter Property="Margin" Value="0,0,0,4" />
         </Style>
 
         <Style x:Key="SidebarToolDescription"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -30,7 +30,7 @@
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Margin" Value="0,0,0,2" />
             <Setter Property="Padding" Value="8,6,24,6" />
-            <Setter Property="MinHeight" Value="34" />
+            <Setter Property="MinHeight" Value="32" />
         </Style>
 
         <Style x:Key="SidebarToolButton"
@@ -39,10 +39,10 @@
             <Setter Property="Background" Value="#FFFFFF" />
             <Setter Property="BorderBrush" Value="#DADDE3" />
             <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="Padding" Value="8,5,24,5" />
+            <Setter Property="Padding" Value="8,4,20,4" />
             <Setter Property="MinWidth" Value="150" />
             <Setter Property="MinHeight" Value="0" />
-            <Setter Property="Margin" Value="0,0,0,3" />
+            <Setter Property="Margin" Value="0,0,0,4" />
         </Style>
 
         <Style x:Key="SidebarToolDescription"
@@ -51,7 +51,7 @@
             <Setter Property="FontWeight" Value="Normal" />
             <Setter Property="TextWrapping" Value="Wrap" />
             <Setter Property="Opacity" Value="0.75" />
-            <Setter Property="Margin" Value="0,1,0,0" />
+            <Setter Property="Margin" Value="0,2,0,0" />
         </Style>
 
         <Style x:Key="ColorSwatchButton"
@@ -128,7 +128,7 @@
                 Background="#FAFAFA"
                 BorderBrush="#E1E4E8"
                 BorderThickness="0,0,1,0">
-            <Grid Margin="8,10,8,8">
+            <Grid Margin="8">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
@@ -136,13 +136,13 @@
                 </Grid.RowDefinitions>
 
                 <StackPanel Grid.Row="0"
-                            Margin="8,0,24,6">
+                            Margin="8,0,20,4">
                     <TextBlock Text="DesktopClock"
                                FontSize="20"
                                FontWeight="SemiBold" />
                     <TextBlock Text="{Binding AppVersion, StringFormat=v{0}}"
                                Foreground="#5B6F8E"
-                               Margin="0,0,0,8" />
+                               Margin="0,0,0,6" />
                 </StackPanel>
 
                 <StackPanel Grid.Row="1"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -35,11 +35,11 @@
 
         <Style x:Key="SidebarToolButton"
                TargetType="Button"
-               BasedOn="{StaticResource {x:Type Button}}">
-            <Setter Property="HorizontalContentAlignment" Value="Left" />
-            <Setter Property="Padding" Value="8,6" />
+               BasedOn="{StaticResource SidebarButton}">
+            <Setter Property="Padding" Value="8,7,24,7" />
             <Setter Property="MinWidth" Value="150" />
-            <Setter Property="Margin" Value="0,0,0,6" />
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="Margin" Value="0,0,0,2" />
         </Style>
 
         <Style x:Key="SidebarToolDescription"
@@ -193,9 +193,6 @@
                         </StackPanel>
                     </Button>
                     <Button Style="{StaticResource SidebarToolButton}"
-                            Background="#256BEF"
-                            BorderBrush="#256BEF"
-                            Foreground="White"
                             Click="CreateNewClock"
                             IsEnabled="{x:Static p:Settings.CanBeSaved}">
                         <StackPanel>

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -108,13 +108,6 @@
                 BorderThickness="0,0,1,0">
             <DockPanel Margin="18,18,18,16">
                 <StackPanel DockPanel.Dock="Top">
-                    <TextBlock Text="DesktopClock"
-                               FontSize="20"
-                               FontWeight="SemiBold" />
-                    <TextBlock Text="Settings"
-                               Foreground="#5B6F8E"
-                               Margin="0,0,0,22" />
-
                     <Button Content="_Display"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=DisplaySection}"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -192,7 +192,7 @@
                         <StackPanel>
                             <AccessText FontWeight="SemiBold"
                                         Text="Settings _folder" />
-                            <TextBlock Text="Open the settings folder."
+                            <TextBlock Text="Open the settings folder"
                                        Style="{StaticResource SidebarToolDescription}" />
                         </StackPanel>
                     </Button>
@@ -202,7 +202,7 @@
                         <StackPanel>
                             <AccessText FontWeight="SemiBold"
                                         Text="Settings f_ile" />
-                            <TextBlock Text="Open the JSON file."
+                            <TextBlock Text="Open the JSON file"
                                        Style="{StaticResource SidebarToolDescription}" />
                         </StackPanel>
                     </Button>
@@ -212,7 +212,7 @@
                         <StackPanel>
                             <AccessText FontWeight="SemiBold"
                                         Text="_New clock" />
-                            <TextBlock Text="Start a fresh copy."
+                            <TextBlock Text="Start a fresh copy"
                                        Style="{StaticResource SidebarToolDescription}" />
                         </StackPanel>
                     </Button>

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -124,11 +124,11 @@
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=TypographySection}"
                             Click="NavigateToSection" />
-                    <Button Content="A_ppearance"
+                    <Button Content="_Appearance"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=AppearanceSection}"
                             Click="NavigateToSection" />
-                    <Button Content="_Alerts"
+                    <Button Content="A_lerts"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=AlertsSection}"
                             Click="NavigateToSection" />

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -135,7 +135,8 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <StackPanel Grid.Row="0">
+                <StackPanel Grid.Row="0"
+                            Margin="8,0,24,0">
                     <TextBlock Text="DesktopClock"
                                FontSize="20"
                                FontWeight="SemiBold" />

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -22,6 +22,17 @@
             <Setter Property="Margin" Value="0,0,0,4" />
         </Style>
 
+        <Style x:Key="SidebarButton"
+               TargetType="Button"
+               BasedOn="{StaticResource {x:Type Button}}">
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Margin" Value="0,0,0,2" />
+            <Setter Property="Padding" Value="12,7" />
+            <Setter Property="MinHeight" Value="34" />
+        </Style>
+
         <Style x:Key="ColorSwatchButton"
                TargetType="Button"
                BasedOn="{StaticResource {x:Type Button}}">
@@ -85,13 +96,84 @@
         </Style>
     </Window.Resources>
 
-    <ScrollViewer x:Name="SettingsScrollViewer"
-                  VerticalScrollBarVisibility="Auto"
-                  HorizontalScrollBarVisibility="Disabled"
-                  ScrollChanged="SettingsScrollViewer_ScrollChanged"
-                  Loaded="SettingsScrollViewer_Loaded">
-        <StackPanel Margin="12">
-            <GroupBox Header="Display"
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="220" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <Border Grid.Column="0"
+                Background="#FAFAFA"
+                BorderBrush="#E1E4E8"
+                BorderThickness="0,0,1,0">
+            <DockPanel Margin="18,18,18,16">
+                <StackPanel DockPanel.Dock="Top">
+                    <TextBlock Text="DesktopClock"
+                               FontSize="20"
+                               FontWeight="SemiBold" />
+                    <TextBlock Text="Settings"
+                               Foreground="#5B6F8E"
+                               Margin="0,0,0,22" />
+
+                    <Button Content="Display"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=DisplaySection}"
+                            Click="NavigateToSection" />
+                    <Button Content="Countdown"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=CountdownSection}"
+                            Click="NavigateToSection" />
+                    <Button Content="Window"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=WindowSection}"
+                            Click="NavigateToSection" />
+                    <Button Content="Typography"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=TypographySection}"
+                            Click="NavigateToSection" />
+                    <Button Content="Appearance"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=AppearanceSection}"
+                            Click="NavigateToSection" />
+                    <Button Content="Alerts"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=AlertsSection}"
+                            Click="NavigateToSection" />
+                    <Button Content="Tools"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=ToolsSection}"
+                            Click="NavigateToSection" />
+                    <Button Content="Shortcuts"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=ShortcutsSection}"
+                            Click="NavigateToSection" />
+                </StackPanel>
+
+                <StackPanel DockPanel.Dock="Bottom"
+                            VerticalAlignment="Bottom">
+                    <Button Content="Settings folder"
+                            Click="OpenSettingsFolder"
+                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
+                    <Button Content="New clock"
+                            Background="#256BEF"
+                            BorderBrush="#256BEF"
+                            Foreground="White"
+                            Click="CreateNewClock"
+                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <ScrollViewer x:Name="SettingsScrollViewer"
+                      Grid.Column="1"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled"
+                      ScrollChanged="SettingsScrollViewer_ScrollChanged"
+                      Loaded="SettingsScrollViewer_Loaded">
+            <StackPanel x:Name="SettingsContent"
+                        Margin="24">
+            <GroupBox x:Name="DisplaySection"
+                      Header="Display"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <TextBlock Text="Clock format"
@@ -129,7 +211,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Countdown"
+            <GroupBox x:Name="CountdownSection"
+                      Header="Countdown"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <TextBlock Text="Countdown target"
@@ -176,7 +259,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Window"
+            <GroupBox x:Name="WindowSection"
+                      Header="Window"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <CheckBox Content="Start with Windows"
@@ -240,7 +324,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Typography"
+            <GroupBox x:Name="TypographySection"
+                      Header="Typography"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <TextBlock Text="Font family"
@@ -319,7 +404,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Appearance"
+            <GroupBox x:Name="AppearanceSection"
+                      Header="Appearance"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <TextBlock Text="Background or outline color"
@@ -455,7 +541,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Alerts"
+            <GroupBox x:Name="AlertsSection"
+                      Header="Alerts"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <TextBlock Text="Alarm sound"
@@ -506,7 +593,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Tools"
+            <GroupBox x:Name="ToolsSection"
+                      Header="Tools"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <Button Content="Open settings folder"
@@ -531,7 +619,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Shortcuts"
+            <GroupBox x:Name="ShortcutsSection"
+                      Header="Shortcuts"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <StackPanel>
@@ -563,7 +652,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Discover More"
+            <GroupBox x:Name="DiscoverMoreSection"
+                      Header="Discover More"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <StackPanel>
@@ -622,7 +712,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Credits"
+            <GroupBox x:Name="CreditsSection"
+                      Header="Credits"
                       Style="{StaticResource CardGroupBox}">
                 <StackPanel Style="{StaticResource CardBodyPanel}">
                     <StackPanel>
@@ -677,6 +768,7 @@
                     </StackPanel>
                 </StackPanel>
             </GroupBox>
-        </StackPanel>
-    </ScrollViewer>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
 </Window>

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -29,8 +29,8 @@
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Margin" Value="0,0,0,2" />
-            <Setter Property="Padding" Value="12,7" />
-            <Setter Property="MinHeight" Value="34" />
+            <Setter Property="Padding" Value="8,8,24,8" />
+            <Setter Property="MinHeight" Value="40" />
         </Style>
 
         <Style x:Key="ColorSwatchButton"
@@ -98,7 +98,7 @@
 
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="220" />
+            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
@@ -106,7 +106,7 @@
                 Background="#FAFAFA"
                 BorderBrush="#E1E4E8"
                 BorderThickness="0,0,1,0">
-            <Grid Margin="18,18,18,16">
+            <Grid Margin="8,18,8,16">
                 <StackPanel VerticalAlignment="Center">
                     <Button Content="_Display"
                             Style="{StaticResource SidebarButton}"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -147,6 +147,14 @@
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=ShortcutsSection}"
                             Click="NavigateToSection" />
+                    <Button Content="Discover _More"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=DiscoverMoreSection}"
+                            Click="NavigateToSection" />
+                    <Button Content="Cr_edits"
+                            Style="{StaticResource SidebarButton}"
+                            Tag="{Binding ElementName=CreditsSection}"
+                            Click="NavigateToSection" />
                 </StackPanel>
 
                 <StackPanel DockPanel.Dock="Bottom"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -106,8 +106,8 @@
                 Background="#FAFAFA"
                 BorderBrush="#E1E4E8"
                 BorderThickness="0,0,1,0">
-            <DockPanel Margin="18,18,18,16">
-                <StackPanel DockPanel.Dock="Top">
+            <Grid Margin="18,18,18,16">
+                <StackPanel VerticalAlignment="Center">
                     <Button Content="_Display"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=DisplaySection}"
@@ -149,20 +149,7 @@
                             Tag="{Binding ElementName=CreditsSection}"
                             Click="NavigateToSection" />
                 </StackPanel>
-
-                <StackPanel DockPanel.Dock="Bottom"
-                            VerticalAlignment="Bottom">
-                    <Button Content="Settings _folder"
-                            Click="OpenSettingsFolder"
-                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
-                    <Button Content="_New clock"
-                            Background="#256BEF"
-                            BorderBrush="#256BEF"
-                            Foreground="White"
-                            Click="CreateNewClock"
-                            IsEnabled="{x:Static p:Settings.CanBeSaved}" />
-                </StackPanel>
-            </DockPanel>
+            </Grid>
         </Border>
 
         <ScrollViewer x:Name="SettingsScrollViewer"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -10,8 +10,8 @@
         Title="DesktopClock Settings"
         Width="{Binding Source={x:Static p:Settings.Default}, Path=SettingsWindowWidth, Mode=TwoWay}"
         Height="{Binding Source={x:Static p:Settings.Default}, Path=SettingsWindowHeight, Mode=TwoWay}"
-        MinWidth="720"
-        MinHeight="520"
+        MinWidth="800"
+        MinHeight="600"
         ResizeMode="CanResize"
         WindowStartupLocation="CenterScreen">
     <Window.Resources>

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -87,6 +87,17 @@ public partial class SettingsWindow : Window
         PickColor(color => ViewModel.Settings.OuterColor = color, ViewModel.Settings.OuterColor);
     }
 
+    private void NavigateToSection(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { Tag: FrameworkElement section })
+        {
+            return;
+        }
+
+        var sectionOffset = section.TransformToAncestor(SettingsContent).Transform(new Point(0, 0)).Y;
+        SettingsScrollViewer.ScrollToVerticalOffset(sectionOffset);
+    }
+
     private void PickColor(Action<Color> applyColor, Color currentColor)
     {
         using var colorDialog = new System.Windows.Forms.ColorDialog

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -103,6 +103,7 @@ public partial class SettingsWindow : Window
         }
 
         SettingsScrollViewer.ScrollToVerticalOffset(targetOffset);
+        section.Focus();
     }
 
     private void PickColor(Action<Color> applyColor, Color currentColor)

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -243,9 +243,15 @@ public partial class SettingsWindowViewModel : ObservableObject
 {
     public Settings Settings { get; }
 
+    /// <summary>
+    /// The file version of the running app.
+    /// </summary>
+    public string AppVersion { get; }
+
     public SettingsWindowViewModel(Settings settings)
     {
         Settings = settings;
+        AppVersion = FileVersionInfo.GetVersionInfo(App.MainFileInfo.FullName).FileVersion;
         FontFamilies = GetAllSystemFonts().Distinct().OrderBy(f => f).ToList();
         FontStyles = ["Normal", "Italic", "Oblique"];
         FontWeights = ["Thin", "ExtraLight", "Light", "Normal", "Medium", "SemiBold", "Bold", "ExtraBold", "Black", "ExtraBlack"];

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -95,7 +95,14 @@ public partial class SettingsWindow : Window
         }
 
         var sectionOffset = section.TransformToAncestor(SettingsContent).Transform(new Point(0, 0)).Y;
-        SettingsScrollViewer.ScrollToVerticalOffset(sectionOffset);
+        var targetOffset = sectionOffset;
+
+        if (section.ActualHeight < SettingsScrollViewer.ViewportHeight)
+        {
+            targetOffset -= (SettingsScrollViewer.ViewportHeight - section.ActualHeight) / 2;
+        }
+
+        SettingsScrollViewer.ScrollToVerticalOffset(targetOffset);
     }
 
     private void PickColor(Action<Color> applyColor, Color currentColor)


### PR DESCRIPTION
Adds a compact sidebar to the settings window with keyboard-accessible navigation for each settings section. The sidebar includes the app name, current version, centered section links, and quick tool actions for opening settings files or creating a new clock.

Selecting a section scrolls it into view, centers it when possible, and moves keyboard focus to the target card for better navigation flow.

<img width="786" height="593" alt="image" src="https://github.com/user-attachments/assets/6801af93-c649-498b-a59f-7131385f964c" />
