### PR TITLE
Re-order menu items

### DIFF
--- a/DesktopClock/MainWindow.xaml
+++ b/DesktopClock/MainWindow.xaml
@@ -41,10 +41,6 @@
             <MenuItem Command="{Binding HideForNowCommand}"
                       Header="_Hide" />
 
-            <MenuItem Header="Stay on _top"
-                      IsCheckable="True"
-                      IsChecked="{Binding Topmost, Source={x:Static p:Settings.Default}, Mode=TwoWay}" />
-
             <MenuItem>
                 <MenuItem.Header>
                     <StackPanel Orientation="Horizontal">
@@ -57,6 +53,10 @@
                     </StackPanel>
                 </MenuItem.Header>
             </MenuItem>
+
+            <MenuItem Header="Stay on _top"
+                      IsCheckable="True"
+                      IsChecked="{Binding Topmost, Source={x:Static p:Settings.Default}, Mode=TwoWay}" />
 
             <MenuItem Command="{Binding OpenSettingsWindowCommand}"
                       Header="_Settings…" />


### PR DESCRIPTION
Swap `Stay on top` and `Size` so if you accidentally click above `Settings` and try to drag your mouse down, you won't get stuck.

<img width="271" height="281" alt="image" src="https://github.com/user-attachments/assets/42abf667-5b05-40f2-bcd4-8332bdba6abb" />
