### PR TITLE
Keep clock active when hidden or minimized

### DIFF
--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -378,19 +378,8 @@ public partial class MainWindow : Window
 
     private void Window_StateChanged(object sender, EventArgs e)
     {
-        if (WindowState == WindowState.Minimized)
-        {
-            // Save resources while minimized.
-            _systemClockTimer.Stop();
-            EfficiencyModeUtilities.SetEfficiencyMode(true);
-        }
-        else
-        {
-            // Resume normal updates.
-            UpdateTimeString();
-            _systemClockTimer.Start();
-            EfficiencyModeUtilities.SetEfficiencyMode(false);
-        }
+        UpdateTimeString();
+        EfficiencyModeUtilities.SetEfficiencyMode(WindowState == WindowState.Minimized);
 
         ApplyWindowVisibilitySettings();
     }

--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -12,7 +12,6 @@ using CommunityToolkit.Mvvm.Input;
 using DesktopClock.Properties;
 using DesktopClock.Utilities;
 using H.NotifyIcon;
-using H.NotifyIcon.EfficiencyMode;
 using WpfWindowPlacement;
 
 namespace DesktopClock;
@@ -379,7 +378,6 @@ public partial class MainWindow : Window
     private void Window_StateChanged(object sender, EventArgs e)
     {
         UpdateTimeString();
-        EfficiencyModeUtilities.SetEfficiencyMode(WindowState == WindowState.Minimized);
 
         ApplyWindowVisibilitySettings();
     }


### PR DESCRIPTION
Minimizing the clock should only change its visibility, not put the app into a reduced-activity state. The previous behavior could stop or deprioritize the timer during StartHidden, which made the clock state less reliable while the app was still running.

This keeps the timer lifecycle predictable: the clock starts updating at startup, continues while hidden or minimized, and only pauses for explicit short-lived interactions like dragging.

Closes #123