### PR TITLE
Improve feedback when actions fail

### DIFF
--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Media;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -66,7 +67,17 @@ public partial class MainWindow : Window
     /// Copies the current time string to the clipboard.
     /// </summary>
     [RelayCommand]
-    public void CopyToClipboard() => Clipboard.SetText(CurrentTimeOrCountdownString);
+    public void CopyToClipboard()
+    {
+        try
+        {
+            Clipboard.SetText(CurrentTimeOrCountdownString);
+        }
+        catch (ExternalException ex) when (ex.ErrorCode == unchecked((int)0x800401D0))
+        {
+            _trayIcon?.ShowNotification("Copy failed", "The clipboard is busy. Try copying again.");
+        }
+    }
 
     /// <summary>
     /// Minimizes the window.
@@ -239,7 +250,7 @@ public partial class MainWindow : Window
         }
         catch
         {
-            // Ignore errors because we don't want a sound issue to crash the app.
+            _trayIcon?.ShowNotification("Alert sound unavailable", "The WAV file couldn't be played.");
         }
     }
 
@@ -403,8 +414,15 @@ public partial class MainWindow : Window
         }
     }
 
-    private static void OpenUrl(string url)
+    private void OpenUrl(string url)
     {
-        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch
+        {
+            _trayIcon?.ShowNotification("Couldn't open link", $"Couldn't open {url}.");
+        }
     }
 }

--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -75,7 +75,7 @@ public partial class MainWindow : Window
         }
         catch (ExternalException)
         {
-            _trayIcon?.ShowNotification("Copy failed", "Couldn't update the clipboard. Try again.");
+            _trayIcon?.ShowNotification("Copy failed", "ouldn't update the clipboard. Try again.");
         }
     }
 
@@ -422,7 +422,7 @@ public partial class MainWindow : Window
         }
         catch
         {
-            _trayIcon?.ShowNotification("Couldn't open link", $"Couldn't open {url}.");
+            _trayIcon?.ShowNotification("Couldn't open link", url);
         }
     }
 }

--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -75,7 +75,7 @@ public partial class MainWindow : Window
         }
         catch (ExternalException)
         {
-            _trayIcon?.ShowNotification("Copy failed", "Windows couldn't update the clipboard. Try again.");
+            _trayIcon?.ShowNotification("Copy failed", "Couldn't update the clipboard. Try again.");
         }
     }
 

--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -73,9 +73,9 @@ public partial class MainWindow : Window
         {
             Clipboard.SetText(CurrentTimeOrCountdownString);
         }
-        catch (ExternalException ex) when (ex.ErrorCode == unchecked((int)0x800401D0))
+        catch (ExternalException)
         {
-            _trayIcon?.ShowNotification("Copy failed", "The clipboard is busy. Try copying again.");
+            _trayIcon?.ShowNotification("Copy failed", "Windows couldn't update the clipboard. Try again.");
         }
     }
 

--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Media;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -73,7 +72,7 @@ public partial class MainWindow : Window
         {
             Clipboard.SetText(CurrentTimeOrCountdownString);
         }
-        catch (ExternalException)
+        catch
         {
             _trayIcon?.ShowNotification("Copy failed", "ouldn't update the clipboard. Try again.");
         }

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -129,7 +129,7 @@ public partial class SettingsWindow : Window
 
     private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
     {
-        Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+        OpenUrl(e.Uri.AbsoluteUri);
         e.Handled = true;
     }
 
@@ -221,9 +221,18 @@ public partial class SettingsWindow : Window
         ViewModel.Settings.SettingsScrollPosition = SettingsScrollViewer.VerticalOffset;
     }
 
-    private static void OpenUrl(string url)
+    private void OpenUrl(string url)
     {
-        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch
+        {
+            MessageBox.Show(this,
+                $"Couldn't open {url}.",
+                Title, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 
     private static void OpenSettingsPath(string filePath)


### PR DESCRIPTION
These changes make failures more understandable instead of letting them fail silently or crash the app. Clipboard, link-opening, and alert playback errors are all cases where the user explicitly asked the app to do something, so the app should explain why nothing appeared to happen and give enough context to recover.

<img width="396" height="148" alt="image" src="https://github.com/user-attachments/assets/e1aee893-1a35-4a38-b881-751f844468d2" />