### PR TITLE
Polish workflows

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -17,4 +17,4 @@ runs:
 
     - name: Test
       shell: bash
-      run: dotnet test -c Release --no-build --logger trx --results-directory TestResults
+      run: dotnet test -c Release --no-build --no-restore --logger trx --results-directory TestResults

--- a/.github/actions/create-release-artifacts/action.yml
+++ b/.github/actions/create-release-artifacts/action.yml
@@ -15,19 +15,16 @@ runs:
   steps:
     - uses: actions/setup-dotnet@v5
 
-    - name: Create Binaries
+    - name: Create binaries
       shell: bash
       run: |
-        arch="${{ inputs.arch }}"
         dotnet tool install --global wix --version 4.0.6
-        dotnet publish ./DesktopClock/DesktopClock.csproj -o "publish/$arch" -c Release --os win --arch "$arch" -p:Version=${{ inputs.version }}
-        wix build Product.wxs -d MainExeSource="publish/$arch/DesktopClock.exe" -o "publish/DesktopClock-${{ inputs.version }}-$arch.msi"
+        dotnet publish ./DesktopClock/DesktopClock.csproj -o "publish/${{ inputs.arch }}" -c Release --os win --arch "${{ inputs.arch }}" -p:Version="${{ inputs.version }}"
+        wix build Product.wxs -d "MainExeSource=publish/${{ inputs.arch }}/DesktopClock.exe" -o "publish/DesktopClock-${{ inputs.version }}-${{ inputs.arch }}.msi"
 
-    - name: Create Portable ZIP
+    - name: Create portable ZIP
       shell: pwsh
-      run: |
-        $arch = "${{ inputs.arch }}"
-        Compress-Archive -Path "publish/$arch/DesktopClock.exe" -DestinationPath "publish/DesktopClock-${{ inputs.version }}-$arch.zip"
+      run: Compress-Archive -Path "publish/${{ inputs.arch }}/DesktopClock.exe" -DestinationPath "publish/DesktopClock-${{ inputs.version }}-${{ inputs.arch }}.zip" -Force
 
     - uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     name: Format
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-dotnet@v5
 
@@ -29,7 +29,7 @@ jobs:
     name: Build and test
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/build-and-test
 
@@ -49,7 +49,7 @@ jobs:
       matrix:
         arch: [x64, arm64]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/create-release-artifacts
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
 
   package:
     name: Package ${{ matrix.arch }}
-    needs: build-test
     runs-on: windows-2025
     strategy:
       fail-fast: false
@@ -48,7 +47,9 @@ jobs:
 
   deploy:
     name: Create GitHub release
-    needs: package
+    needs:
+      - build-test
+      - package
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,26 +19,27 @@ on:
         default: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-test:
     name: Build and test
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/build-and-test
 
   package:
     name: Package ${{ matrix.arch }}
+    needs: build-test
     runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:
         arch: [x64, arm64]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/create-release-artifacts
         with:
@@ -47,10 +48,10 @@ jobs:
 
   deploy:
     name: Create GitHub release
-    needs:
-      - build-test
-      - package
-    runs-on: windows-2025
+    needs: package
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -65,7 +66,7 @@ jobs:
           tag: "v${{ inputs.version }}"
           artifacts: "release-artifacts/*.zip,release-artifacts/*.msi"
           generateReleaseNotes: true
-          prerelease: ${{ contains(inputs.version, 'preview') }}
+          prerelease: ${{ contains(inputs.version, '-') }}
           allowUpdates: ${{ inputs.updateRelease }}
           removeArtifacts: true
           omitBodyDuringUpdate: true


### PR DESCRIPTION
## Summary

Polishes the existing GitHub Actions setup without expanding the workflow surface area.

The release flow now matches the actual dependencies:

- `build-test` validates the solution and tests.
- `package` independently publishes/builds the app for each architecture through `dotnet publish`.
- `deploy` waits for both successful tests and successful packages before creating a release.

## Line-by-line explanation

### `.github/actions/build-and-test/action.yml`

- Line 20: Adds `--no-restore` to `dotnet test` because the composite action already runs `dotnet restore` before build and test, keeping test execution consistent with the existing `--no-build` optimization.

### `.github/actions/create-release-artifacts/action.yml`

- Line 18: Renames `Create Binaries` to `Create binaries` for sentence-case step naming that matches the adjacent step style.
- Removed previous `arch="${{ inputs.arch }}"`: avoids an extra shell variable and uses the action input directly where it is needed.
- Line 22: Replaces `$arch` with `${{ inputs.arch }}` in the publish output path and `--arch` argument, and quotes `${{ inputs.version }}` in the MSBuild property value.
- Line 23: Replaces `$arch` with `${{ inputs.arch }}` in the WiX source path and output filename, and quotes the WiX define argument so the full `MainExeSource=...` value is passed as one argument.
- Line 25: Renames `Create Portable ZIP` to `Create portable ZIP` for sentence-case step naming.
- Line 27: Collapses the ZIP step to one PowerShell command, uses `${{ inputs.arch }}` directly, uses `${{ inputs.version }}` directly, and adds `-Force` so reruns overwrite an existing ZIP path instead of failing on a stale file.

### `.github/workflows/build.yml`

- Line 16: Updates the format job checkout from `actions/checkout@v5` to `actions/checkout@v6`.
- Line 32: Updates the build/test job checkout from `actions/checkout@v5` to `actions/checkout@v6`.
- Line 52: Updates the package job checkout from `actions/checkout@v5` to `actions/checkout@v6`.

### `.github/workflows/deploy.yml`

- Line 22: Changes the workflow-level token permission from `contents: write` to `contents: read`, so write permission is no longer granted to every release job by default.
- Line 29: Updates the build/test job checkout from `actions/checkout@v5` to `actions/checkout@v6`.
- Line 41: Updates the package job checkout from `actions/checkout@v5` to `actions/checkout@v6`.
- Lines 50-52: Makes release creation wait for both `build-test` and `package`; package no longer waits for tests because `dotnet publish` performs its own build, but deploy remains gated on both validation paths.
- Line 53: Moves the release creation job from `windows-2025` to `ubuntu-24.04` because it only downloads artifacts and calls the GitHub release action.
- Lines 54-55: Gives only the deploy job `contents: write`, keeping release publishing permission scoped to the job that needs it.
- Line 70: Changes prerelease detection from `contains(inputs.version, 'preview')` to `contains(inputs.version, '-')`, matching SemVer prerelease syntax such as `1.2.3-preview.1`, `1.2.3-beta.1`, or `1.2.3-rc.1`.

## Validation

- `actionlint`
- `git diff --check`
