### PR TITLE
Simplify release workflow

### DIFF
--- a/.github/actions/create-release-artifacts/action.yml
+++ b/.github/actions/create-release-artifacts/action.yml
@@ -1,6 +1,6 @@
 name: Create release artifacts
 
-description: Creates release-ready binaries and uploads them as artifacts.
+description: Creates release-ready binaries.
 
 inputs:
   version:
@@ -18,18 +18,10 @@ runs:
     - name: Create binaries
       shell: bash
       run: |
-        dotnet tool install --global wix --version 4.0.6
+        dotnet tool update --global wix --version 4.0.6
         dotnet publish ./DesktopClock/DesktopClock.csproj -o "publish/${{ inputs.arch }}" -c Release --os win --arch "${{ inputs.arch }}" -p:Version="${{ inputs.version }}"
         wix build Product.wxs -d "MainExeSource=publish/${{ inputs.arch }}/DesktopClock.exe" -o "publish/DesktopClock-${{ inputs.version }}-${{ inputs.arch }}.msi"
 
     - name: Create portable ZIP
       shell: pwsh
       run: Compress-Archive -Path "publish/${{ inputs.arch }}/DesktopClock.exe" -DestinationPath "publish/DesktopClock-${{ inputs.version }}-${{ inputs.arch }}.zip" -Force
-
-    - uses: actions/upload-artifact@v7
-      with:
-        name: desktopclock-${{ inputs.arch }}
-        if-no-files-found: error
-        path: |
-          publish/*.zip
-          publish/*.msi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,11 @@ jobs:
       - uses: ./.github/actions/create-release-artifacts
         with:
           arch: ${{ matrix.arch }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: desktopclock-${{ matrix.arch }}
+          if-no-files-found: error
+          path: |
+            publish/*.zip
+            publish/*.msi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,53 +19,35 @@ on:
         default: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  build-test:
-    name: Build and test
+  release:
+    name: Release
     runs-on: windows-2025
     steps:
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/build-and-test
 
-  package:
-    name: Package ${{ matrix.arch }}
-    runs-on: windows-2025
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [x64, arm64]
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: ./.github/actions/create-release-artifacts
+      - name: Package x64
+        uses: ./.github/actions/create-release-artifacts
         with:
           version: ${{ inputs.version }}
-          arch: ${{ matrix.arch }}
+          arch: x64
 
-  deploy:
-    name: Create GitHub release
-    needs:
-      - build-test
-      - package
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v8
+      - name: Package arm64
+        uses: ./.github/actions/create-release-artifacts
         with:
-          pattern: desktopclock-*
-          path: release-artifacts
-          merge-multiple: true
+          version: ${{ inputs.version }}
+          arch: arm64
 
       - name: Create GitHub release
         if: ${{ !inputs.dryRun }}
         uses: ncipollo/release-action@v1.21.0
         with:
           tag: "v${{ inputs.version }}"
-          artifacts: "release-artifacts/*.zip,release-artifacts/*.msi"
+          artifacts: "publish/*.zip,publish/*.msi"
           generateReleaseNotes: true
           prerelease: ${{ contains(inputs.version, '-') }}
           allowUpdates: ${{ inputs.updateRelease }}


### PR DESCRIPTION
## Summary

Simplifies the manual release workflow for this repo's release cadence and makes the artifact action cleaner as a reusable template.

## What changed

- Collapsed `deploy.yml` from three jobs into one sequential `Release` job.
- Kept CI packaging parallel, but moved artifact upload out of the composite action and into `build.yml`.
- Changed `create-release-artifacts` so it only creates release files; callers decide whether to upload them as workflow artifacts or publish them to a GitHub release.
- Made WiX setup idempotent with `dotnet tool update --global wix --version 4.0.6`, so the release job can package both architectures in one job.
- Removed the release workflow's cross-job artifact upload/download round trip.

## Why

The release workflow is manually triggered and rare, so a sequential flow is easier to read and maintain than a parallel build/package/deploy graph. `dotnet publish` already builds the app for each architecture, and the release job now runs tests first, then packages x64 and arm64, then creates the release from local `publish/*.zip` and `publish/*.msi` files.

CI still validates packaging for each architecture through the existing matrix, and CI remains responsible for uploading those package outputs as workflow artifacts.

## Validation

- `actionlint`
- `git diff --check`
- `dotnet restore`
- `dotnet build -c Release --no-restore`
- `dotnet test -c Release --no-build --no-restore --logger trx --results-directory TestResults`
- Local sequential x64 and arm64 packaging using the updated WiX setup flow
