### PR TITLE
Windows 11 retheme: dark mode, accent color, and Fluent control templates

### DIFF
--- a/DesktopClock/App.xaml
+++ b/DesktopClock/App.xaml
@@ -6,6 +6,8 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/FluentTheme.xaml" />
+                <!-- Design-time default; ThemeManager swaps this for the system theme at runtime. -->
+                <ResourceDictionary Source="Themes/LightPalette.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/DesktopClock/App.xaml.cs
+++ b/DesktopClock/App.xaml.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using DesktopClock.Utilities;
 using Microsoft.Win32;
 
 namespace DesktopClock;
@@ -14,6 +15,12 @@ public partial class App : Application
 {
     public static FileInfo MainFileInfo = new(Process.GetCurrentProcess().MainModule.FileName);
     public static string MainFileDisplayText = $"{Path.GetFileNameWithoutExtension(MainFileInfo.Name)} {FileVersionInfo.GetVersionInfo(MainFileInfo.FullName).FileVersion}";
+
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        ThemeManager.Initialize();
+    }
 
     /// <summary>
     /// Sets or deletes a value in the registry which enables the current executable to run on system startup.

--- a/DesktopClock/MainWindow.xaml
+++ b/DesktopClock/MainWindow.xaml
@@ -36,10 +36,20 @@
             <Separator />
 
             <MenuItem Command="{Binding CopyToClipboardCommand}"
-                      Header="_Copy" />
+                      Header="_Copy">
+                <MenuItem.Icon>
+                    <TextBlock Text="&#xE8C8;"
+                               Style="{StaticResource MenuIconGlyph}" />
+                </MenuItem.Icon>
+            </MenuItem>
 
             <MenuItem Command="{Binding HideForNowCommand}"
-                      Header="_Hide" />
+                      Header="_Hide">
+                <MenuItem.Icon>
+                    <TextBlock Text="&#xE890;"
+                               Style="{StaticResource MenuIconGlyph}" />
+                </MenuItem.Icon>
+            </MenuItem>
 
             <MenuItem>
                 <MenuItem.Header>
@@ -59,18 +69,38 @@
                       IsChecked="{Binding Topmost, Source={x:Static p:Settings.Default}, Mode=TwoWay}" />
 
             <MenuItem Command="{Binding OpenSettingsWindowCommand}"
-                      Header="_Settings…" />
+                      Header="_Settings…">
+                <MenuItem.Icon>
+                    <TextBlock Text="&#xE713;"
+                               Style="{StaticResource MenuIconGlyph}" />
+                </MenuItem.Icon>
+            </MenuItem>
 
             <Separator />
 
             <MenuItem Command="{Binding OpenReleasesPageCommand}"
-                      Header="Check for _updates" />
+                      Header="Check for _updates">
+                <MenuItem.Icon>
+                    <TextBlock Text="&#xE895;"
+                               Style="{StaticResource MenuIconGlyph}" />
+                </MenuItem.Icon>
+            </MenuItem>
 
             <MenuItem Command="{Binding OpenIssueTrackerCommand}"
-                      Header="Give _feedback" />
+                      Header="Give _feedback">
+                <MenuItem.Icon>
+                    <TextBlock Text="&#xED15;"
+                               Style="{StaticResource MenuIconGlyph}" />
+                </MenuItem.Icon>
+            </MenuItem>
 
             <MenuItem Command="{Binding ExitCommand}"
-                      Header="E_xit" />
+                      Header="E_xit">
+                <MenuItem.Icon>
+                    <TextBlock Text="&#xE7E8;"
+                               Style="{StaticResource MenuIconGlyph}" />
+                </MenuItem.Icon>
+            </MenuItem>
         </ContextMenu>
 
         <tb:TaskbarIcon x:Key="TrayIcon"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -28,10 +28,7 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
-        <Border Grid.Column="0"
-                Background="{DynamicResource SubtleBrush}"
-                BorderBrush="{DynamicResource SeparatorBrush}"
-                BorderThickness="0,0,1,0">
+        <Border Grid.Column="0">
             <Grid Margin="8">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -49,8 +46,8 @@
                                Margin="0,0,0,6" />
                 </StackPanel>
 
-                <StackPanel Grid.Row="1"
-                            VerticalAlignment="Center">
+                <StackPanel x:Name="NavPanel"
+                            Grid.Row="1">
                     <Button Content="_Display"
                             Style="{StaticResource SidebarButton}"
                             Tag="{Binding ElementName=DisplaySection}"

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -16,7 +16,10 @@
         WindowStartupLocation="CenterScreen"
         FontFamily="Segoe UI Variable Text, Segoe UI"
         FontSize="13"
-        UseLayoutRounding="True">
+        UseLayoutRounding="True"
+        Background="{DynamicResource WindowBackgroundBrush}"
+        Foreground="{DynamicResource TextPrimaryBrush}"
+        SourceInitialized="Window_SourceInitialized">
 
 
     <Grid>

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -30,6 +30,11 @@ public partial class SettingsWindow : Window
 
     private SettingsWindowViewModel ViewModel => (SettingsWindowViewModel)DataContext;
 
+    private void Window_SourceInitialized(object sender, EventArgs e)
+    {
+        Utilities.ThemeManager.ApplyTitleBarTheme(this);
+    }
+
     private void SelectFormat(object sender, SelectionChangedEventArgs e)
     {
         if (e.AddedItems.Count == 0)

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -20,6 +20,7 @@ namespace DesktopClock;
 public partial class SettingsWindow : Window
 {
     private bool _restoringScrollPosition = true;
+    private DateTime _navClickTime = DateTime.MinValue;
 
     public SettingsWindow()
     {
@@ -94,7 +95,7 @@ public partial class SettingsWindow : Window
 
     private void NavigateToSection(object sender, RoutedEventArgs e)
     {
-        if (sender is not Button { Tag: FrameworkElement section })
+        if (sender is not Button { Tag: FrameworkElement section } button)
         {
             return;
         }
@@ -106,6 +107,11 @@ public partial class SettingsWindow : Window
         {
             targetOffset -= (SettingsScrollViewer.ViewportHeight - section.ActualHeight) / 2;
         }
+
+        // Highlight the clicked button directly; scroll positions near the ends can map to
+        // several sections, so geometry alone can't always tell which one was chosen.
+        _navClickTime = DateTime.UtcNow;
+        SetActiveNavButton(button);
 
         SettingsScrollViewer.ScrollToVerticalOffset(targetOffset);
         section.Focus();
@@ -233,25 +239,54 @@ public partial class SettingsWindow : Window
             return;
         }
 
-        // The active section is the last one whose top has scrolled past the upper part of the viewport.
-        var threshold = SettingsScrollViewer.VerticalOffset + SettingsScrollViewer.ViewportHeight / 3;
-        Button activeButton = null;
-
-        foreach (var button in NavPanel.Children.OfType<Button>())
+        // A click already set the highlight; the scroll it caused shouldn't recompute it.
+        if ((DateTime.UtcNow - _navClickTime).TotalMilliseconds < 500)
         {
-            if (button.Tag is not FrameworkElement section)
-            {
-                continue;
-            }
+            return;
+        }
 
-            var sectionOffset = section.TransformToAncestor(SettingsContent).Transform(new Point(0, 0)).Y;
+        var buttons = NavPanel.Children.OfType<Button>().Where(b => b.Tag is FrameworkElement).ToList();
 
-            if (sectionOffset <= threshold || activeButton == null)
+        if (buttons.Count == 0)
+        {
+            return;
+        }
+
+        Button activeButton;
+
+        if (SettingsScrollViewer.VerticalOffset <= 1)
+        {
+            // Pinned to the top: always the first section.
+            activeButton = buttons[0];
+        }
+        else if (SettingsScrollViewer.VerticalOffset >= SettingsScrollViewer.ScrollableHeight - 1)
+        {
+            // Pinned to the bottom: always the last section, which can never scroll past the probe.
+            activeButton = buttons[buttons.Count - 1];
+        }
+        else
+        {
+            // Otherwise the active section is the one containing the middle of the viewport.
+            var probe = SettingsScrollViewer.VerticalOffset + SettingsScrollViewer.ViewportHeight / 2;
+            activeButton = buttons[0];
+
+            foreach (var button in buttons)
             {
-                activeButton = button;
+                var section = (FrameworkElement)button.Tag;
+                var sectionOffset = section.TransformToAncestor(SettingsContent).Transform(new Point(0, 0)).Y;
+
+                if (sectionOffset <= probe)
+                {
+                    activeButton = button;
+                }
             }
         }
 
+        SetActiveNavButton(activeButton);
+    }
+
+    private void SetActiveNavButton(Button activeButton)
+    {
         foreach (var button in NavPanel.Children.OfType<Button>())
         {
             NavButton.SetIsActive(button, button == activeButton);

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -213,12 +213,49 @@ public partial class SettingsWindow : Window
 
     private void SettingsScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
     {
+        UpdateActiveNavButton();
+
         if (_restoringScrollPosition)
         {
             return;
         }
 
         ViewModel.Settings.SettingsScrollPosition = e.VerticalOffset;
+    }
+
+    /// <summary>
+    /// Marks the sidebar button whose section is currently in view.
+    /// </summary>
+    private void UpdateActiveNavButton()
+    {
+        if (!SettingsContent.IsLoaded)
+        {
+            return;
+        }
+
+        // The active section is the last one whose top has scrolled past the upper part of the viewport.
+        var threshold = SettingsScrollViewer.VerticalOffset + SettingsScrollViewer.ViewportHeight / 3;
+        Button activeButton = null;
+
+        foreach (var button in NavPanel.Children.OfType<Button>())
+        {
+            if (button.Tag is not FrameworkElement section)
+            {
+                continue;
+            }
+
+            var sectionOffset = section.TransformToAncestor(SettingsContent).Transform(new Point(0, 0)).Y;
+
+            if (sectionOffset <= threshold || activeButton == null)
+            {
+                activeButton = button;
+            }
+        }
+
+        foreach (var button in NavPanel.Children.OfType<Button>())
+        {
+            NavButton.SetIsActive(button, button == activeButton);
+        }
     }
 
     private void SettingsWindow_Closing(object sender, CancelEventArgs e)
@@ -251,6 +288,19 @@ public partial class SettingsWindow : Window
 
         Process.Start(new ProcessStartInfo("explorer.exe", folderPath) { UseShellExecute = true });
     }
+}
+
+/// <summary>
+/// Attached property that marks the sidebar navigation button for the section currently in view.
+/// </summary>
+public static class NavButton
+{
+    public static readonly DependencyProperty IsActiveProperty = DependencyProperty.RegisterAttached(
+        "IsActive", typeof(bool), typeof(NavButton), new PropertyMetadata(false));
+
+    public static bool GetIsActive(DependencyObject obj) => (bool)obj.GetValue(IsActiveProperty);
+
+    public static void SetIsActive(DependencyObject obj, bool value) => obj.SetValue(IsActiveProperty, value);
 }
 
 public partial class SettingsWindowViewModel : ObservableObject

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -267,7 +267,7 @@ public partial class SettingsWindow : Window
         else
         {
             // Otherwise the active section is the one containing the middle of the viewport.
-            var probe = SettingsScrollViewer.VerticalOffset + SettingsScrollViewer.ViewportHeight / 2;
+            var probe = SettingsScrollViewer.VerticalOffset + (SettingsScrollViewer.ViewportHeight / 2);
             activeButton = buttons[0];
 
             foreach (var button in buttons)

--- a/DesktopClock/Themes/DarkPalette.xaml
+++ b/DesktopClock/Themes/DarkPalette.xaml
@@ -1,0 +1,25 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Dark palette — mirrors Windows 11 dark mode surfaces. -->
+
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#202020" />
+    <SolidColorBrush x:Key="SubtleBrush" Color="#262626" />
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#2B2B2B" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#383838" />
+    <SolidColorBrush x:Key="SeparatorBrush" Color="#3F3F3F" />
+    <SolidColorBrush x:Key="TextPrimaryBrush" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="TextSecondaryBrush" Color="#A6A6A6" />
+    <SolidColorBrush x:Key="HoverBrush" Color="#383838" />
+    <SolidColorBrush x:Key="PressedBrush" Color="#303030" />
+    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#2E2E2E" />
+    <SolidColorBrush x:Key="ButtonBorderBrush" Color="#404040" />
+    <SolidColorBrush x:Key="ControlFillBrush" Color="#2E2E2E" />
+    <SolidColorBrush x:Key="ControlBorderBrush" Color="#454545" />
+    <SolidColorBrush x:Key="MenuBackgroundBrush" Color="#2C2C2C" />
+    <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="#6B6B6B" />
+
+    <!-- Fallback when the system accent can't be read; ThemeManager overrides at runtime. -->
+    <SolidColorBrush x:Key="AccentBrush" Color="#4CC2FF" />
+
+</ResourceDictionary>

--- a/DesktopClock/Themes/DarkPalette.xaml
+++ b/DesktopClock/Themes/DarkPalette.xaml
@@ -18,6 +18,11 @@
     <SolidColorBrush x:Key="ControlBorderBrush" Color="#454545" />
     <SolidColorBrush x:Key="MenuBackgroundBrush" Color="#2C2C2C" />
     <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="#6B6B6B" />
+    <SolidColorBrush x:Key="SliderTrackBrush" Color="#757575" />
+    <SolidColorBrush x:Key="SliderThumbBackgroundBrush" Color="#454545" />
+
+    <!-- Foreground for glyphs sitting on an accent fill; dark mode lightens the accent so dark glyphs read better. -->
+    <SolidColorBrush x:Key="OnAccentBrush" Color="#1B1B1B" />
 
     <!-- Fallback when the system accent can't be read; ThemeManager overrides at runtime. -->
     <SolidColorBrush x:Key="AccentBrush" Color="#4CC2FF" />

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -713,10 +713,6 @@
     </Style>
 
     <!-- ═══════════════════════════════════════════════════════════ -->
-    <!-- Separator (within menus)                                    -->
-    <!-- ═══════════════════════════════════════════════════════════ -->
-
-    <!-- ═══════════════════════════════════════════════════════════ -->
     <!-- ScrollBar — thin Win11-style rail                           -->
     <!-- ═══════════════════════════════════════════════════════════ -->
 
@@ -811,7 +807,13 @@
         </Style.Triggers>
     </Style>
 
-    <Style TargetType="{x:Type Separator}">
+    <!-- ═══════════════════════════════════════════════════════════ -->
+    <!-- Separator (within menus)                                    -->
+    <!-- ═══════════════════════════════════════════════════════════ -->
+
+    <!-- Menus assign separators the MenuItem.SeparatorStyleKey style; an implicit style is never picked up. -->
+    <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}"
+           TargetType="{x:Type Separator}">
         <Setter Property="Height" Value="1" />
         <Setter Property="Margin" Value="6,4" />
         <Setter Property="SnapsToDevicePixels" Value="True" />

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -2,27 +2,12 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!-- ═══════════════════════════════════════════════════════════ -->
-    <!-- Tokens — Colors & Geometry                                  -->
+    <!-- Tokens — Geometry (colors live in LightPalette/DarkPalette) -->
     <!-- ═══════════════════════════════════════════════════════════ -->
 
     <CornerRadius x:Key="ControlCornerRadius">4</CornerRadius>
     <CornerRadius x:Key="CardCornerRadius">8</CornerRadius>
     <CornerRadius x:Key="MenuCornerRadius">8</CornerRadius>
-
-    <SolidColorBrush x:Key="SubtleBrush" Color="#F5F5F5" />
-    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#FFFFFF" />
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#E5E5E5" />
-    <SolidColorBrush x:Key="SeparatorBrush" Color="#E5E5E5" />
-    <SolidColorBrush x:Key="TextSecondaryBrush" Color="#636363" />
-    <SolidColorBrush x:Key="HoverBrush" Color="#E9E9E9" />
-    <SolidColorBrush x:Key="PressedBrush" Color="#DFDFDF" />
-    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#FBFBFB" />
-    <SolidColorBrush x:Key="ButtonBorderBrush" Color="#E0E0E0" />
-
-    <!-- System-aware brushes for accessibility / high-contrast -->
-    <SolidColorBrush x:Key="TextPrimaryBrush" Color="{DynamicResource {x:Static SystemColors.ControlTextColorKey}}" />
-    <SolidColorBrush x:Key="AccentBrush" Color="{DynamicResource {x:Static SystemColors.HighlightColorKey}}" />
-    <SolidColorBrush x:Key="MenuBackgroundBrush" Color="{DynamicResource {x:Static SystemColors.MenuColorKey}}" />
 
     <!-- ═══════════════════════════════════════════════════════════ -->
     <!-- Button                                                      -->
@@ -132,7 +117,10 @@
         <Setter Property="Padding" Value="6,4" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ControlFillBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource TextPrimaryBrush}" />
         <Setter Property="Margin" Value="0,0,0,4" />
         <Setter Property="SelectionBrush" Value="{DynamicResource AccentBrush}" />
     </Style>
@@ -144,7 +132,7 @@
     <Style TargetType="{x:Type ComboBox}">
         <Setter Property="MinHeight" Value="28" />
         <Setter Property="Padding" Value="6,4" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderBrush}" />
         <Setter Property="Margin" Value="0,0,0,4" />
     </Style>
 
@@ -154,6 +142,7 @@
 
     <Style TargetType="{x:Type CheckBox}">
         <Setter Property="Margin" Value="0,2,0,6" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
     </Style>
 
     <!-- ═══════════════════════════════════════════════════════════ -->

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -529,6 +529,32 @@
     </Style>
 
     <!-- ═══════════════════════════════════════════════════════════ -->
+    <!-- ToolTip                                                     -->
+    <!-- ═══════════════════════════════════════════════════════════ -->
+
+    <Style TargetType="{x:Type ToolTip}">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+        <Setter Property="Background" Value="{DynamicResource MenuBackgroundBrush}" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="Padding" Value="8,5" />
+        <Setter Property="HasDropShadow" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToolTip}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{DynamicResource CardBorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="{DynamicResource ControlCornerRadius}"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ═══════════════════════════════════════════════════════════ -->
     <!-- Hyperlink                                                   -->
     <!-- ═══════════════════════════════════════════════════════════ -->
 

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -616,6 +616,15 @@
     <!-- MenuItem                                                    -->
     <!-- ═══════════════════════════════════════════════════════════ -->
 
+    <!-- Segoe Fluent Icons glyph for MenuItem.Icon; falls back to MDL2 on Windows 10. -->
+    <Style x:Key="MenuIconGlyph"
+           TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="Segoe Fluent Icons, Segoe MDL2 Assets" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
     <Style TargetType="{x:Type MenuItem}">
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
@@ -643,7 +652,7 @@
                             <Path x:Name="CheckMark"
                                   Grid.Column="0"
                                   Data="M 2,5 L 5,8.5 L 11,1"
-                                  Stroke="{TemplateBinding Foreground}"
+                                  Stroke="{DynamicResource AccentBrush}"
                                   StrokeThickness="1.5"
                                   StrokeStartLineCap="Round"
                                   StrokeEndLineCap="Round"
@@ -659,8 +668,7 @@
                                               VerticalAlignment="Center"
                                               Width="16"
                                               Height="16"
-                                              Margin="0,0,6,0"
-                                              Visibility="Collapsed" />
+                                              Margin="0,0,6,0" />
 
                             <!-- Header -->
                             <ContentPresenter Grid.Column="1"

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -177,6 +177,37 @@
         <Setter Property="CaretBrush" Value="{DynamicResource TextPrimaryBrush}" />
         <Setter Property="Margin" Value="0,0,0,4" />
         <Setter Property="SelectionBrush" Value="{DynamicResource AccentBrush}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TextBox}">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{DynamicResource ControlCornerRadius}"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      Focusable="False"
+                                      HorizontalScrollBarVisibility="Hidden"
+                                      VerticalScrollBarVisibility="Hidden"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource SliderTrackBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- ═══════════════════════════════════════════════════════════ -->

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -813,14 +813,13 @@
 
     <Style TargetType="{x:Type Separator}">
         <Setter Property="Height" Value="1" />
-        <Setter Property="Margin" Value="28,4,8,4" />
+        <Setter Property="Margin" Value="6,4" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Separator}">
                     <Border Background="{DynamicResource SeparatorBrush}"
                             Height="1"
-                            Margin="{TemplateBinding Margin}"
                             SnapsToDevicePixels="True" />
                 </ControlTemplate>
             </Setter.Value>

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:DesktopClock">
 
     <!-- ═══════════════════════════════════════════════════════════ -->
     <!-- Tokens — Geometry (colors live in LightPalette/DarkPalette) -->
@@ -68,15 +69,68 @@
     <!-- ═══════════════════════════════════════════════════════════ -->
 
     <Style x:Key="SidebarButton"
-           TargetType="Button"
-           BasedOn="{StaticResource {x:Type Button}}">
+           TargetType="Button">
         <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Margin" Value="0,0,0,2" />
         <Setter Property="Padding" Value="12,8,24,8" />
         <Setter Property="MinHeight" Value="34" />
         <Setter Property="FontSize" Value="13" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{DynamicResource ControlCornerRadius}"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <Grid>
+                            <!-- Accent pill marking the section currently in view -->
+                            <Rectangle x:Name="ActivePill"
+                                       Width="3"
+                                       Height="16"
+                                       RadiusX="1.5"
+                                       RadiusY="1.5"
+                                       Fill="{DynamicResource AccentBrush}"
+                                       HorizontalAlignment="Left"
+                                       VerticalAlignment="Center"
+                                       Margin="-9,0,0,0"
+                                       Visibility="Collapsed" />
+                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Focusable="False"
+                                              RecognizesAccessKey="True" />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="local:NavButton.IsActive" Value="True">
+                            <Setter TargetName="ActivePill" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource PressedBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="border" Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="SidebarToolButton"

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -129,11 +129,152 @@
     <!-- ComboBox                                                    -->
     <!-- ═══════════════════════════════════════════════════════════ -->
 
+    <Style TargetType="{x:Type ComboBoxItem}">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+        <Setter Property="Padding" Value="10,6" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ComboBoxItem}">
+                    <Border x:Name="Border"
+                            Background="Transparent"
+                            CornerRadius="{DynamicResource ControlCornerRadius}"
+                            Padding="{TemplateBinding Padding}"
+                            Margin="2,1"
+                            SnapsToDevicePixels="True">
+                        <Grid>
+                            <!-- Accent pill marking the selected item -->
+                            <Rectangle x:Name="SelectionPill"
+                                       Width="3"
+                                       Height="14"
+                                       RadiusX="1.5"
+                                       RadiusY="1.5"
+                                       Fill="{DynamicResource AccentBrush}"
+                                       HorizontalAlignment="Left"
+                                       VerticalAlignment="Center"
+                                       Margin="-7,0,0,0"
+                                       Visibility="Collapsed" />
+                            <ContentPresenter VerticalAlignment="Center" />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                            <Setter TargetName="SelectionPill" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style TargetType="{x:Type ComboBox}">
         <Setter Property="MinHeight" Value="28" />
-        <Setter Property="Padding" Value="6,4" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderBrush}" />
+        <Setter Property="Padding" Value="10,4" />
         <Setter Property="Margin" Value="0,0,0,4" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ControlFillBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ComboBox}">
+                    <Grid>
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{DynamicResource ControlCornerRadius}"
+                                SnapsToDevicePixels="True" />
+
+                        <ToggleButton Focusable="False"
+                                      ClickMode="Press"
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                            <ToggleButton.Template>
+                                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                                    <Border Background="Transparent" />
+                                </ControlTemplate>
+                            </ToggleButton.Template>
+                        </ToggleButton>
+
+                        <ContentPresenter Margin="10,0,26,0"
+                                          VerticalAlignment="Center"
+                                          IsHitTestVisible="False"
+                                          Content="{TemplateBinding SelectionBoxItem}"
+                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                          ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" />
+
+                        <!-- Chevron -->
+                        <Path Data="M 0,0 L 4.5,4.5 L 9,0"
+                              Stroke="{DynamicResource TextSecondaryBrush}"
+                              StrokeThickness="1.5"
+                              StrokeStartLineCap="Round"
+                              StrokeEndLineCap="Round"
+                              HorizontalAlignment="Right"
+                              VerticalAlignment="Center"
+                              Margin="0,1,10,0"
+                              IsHitTestVisible="False" />
+
+                        <Popup x:Name="PART_Popup"
+                               Placement="Bottom"
+                               VerticalOffset="4"
+                               HorizontalOffset="-4"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               AllowsTransparency="True"
+                               PopupAnimation="Slide"
+                               Focusable="False">
+                            <!-- Outer transparent border gives room for the shadow -->
+                            <Border Padding="4">
+                                <Border Background="{DynamicResource MenuBackgroundBrush}"
+                                        BorderBrush="{DynamicResource CardBorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="{DynamicResource MenuCornerRadius}"
+                                        Padding="2,4"
+                                        SnapsToDevicePixels="True"
+                                        MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                        MaxHeight="{TemplateBinding MaxDropDownHeight}">
+                                    <Border.Effect>
+                                        <DropShadowEffect ShadowDepth="3"
+                                                          Direction="270"
+                                                          Opacity="0.14"
+                                                          BlurRadius="12"
+                                                          Color="#000000" />
+                                    </Border.Effect>
+                                    <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                                  HorizontalScrollBarVisibility="Disabled">
+                                        <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
+                                    </ScrollViewer>
+                                </Border>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsDropDownOpen" Value="True">
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource PressedBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                            <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- ═══════════════════════════════════════════════════════════ -->
@@ -143,14 +284,163 @@
     <Style TargetType="{x:Type CheckBox}">
         <Setter Property="Margin" Value="0,2,0,6" />
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type CheckBox}">
+                    <Grid Background="Transparent">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <Border x:Name="Box"
+                                Width="18"
+                                Height="18"
+                                CornerRadius="{DynamicResource ControlCornerRadius}"
+                                Background="{DynamicResource ControlFillBrush}"
+                                BorderBrush="{DynamicResource SliderTrackBrush}"
+                                BorderThickness="1"
+                                VerticalAlignment="Center"
+                                SnapsToDevicePixels="True">
+                            <Path x:Name="CheckGlyph"
+                                  Data="M 3,8 L 6.5,11.5 L 13,4.5"
+                                  Stroke="{DynamicResource OnAccentBrush}"
+                                  StrokeThickness="1.6"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round"
+                                  StrokeLineJoin="Round"
+                                  Visibility="Collapsed" />
+                        </Border>
+
+                        <ContentPresenter Grid.Column="1"
+                                          Margin="8,0,0,0"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          RecognizesAccessKey="True" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="Box" Property="Background" Value="{DynamicResource AccentBrush}" />
+                            <Setter TargetName="Box" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                            <Setter TargetName="CheckGlyph" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="IsChecked" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Box" Property="Background" Value="{DynamicResource HoverBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="IsChecked" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Box" Property="Opacity" Value="0.9" />
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- ═══════════════════════════════════════════════════════════ -->
     <!-- Slider                                                      -->
     <!-- ═══════════════════════════════════════════════════════════ -->
 
+    <Style x:Key="SliderTrackRepeatButton"
+           TargetType="RepeatButton">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <Border Background="Transparent"
+                            Height="18">
+                        <Border Height="4"
+                                CornerRadius="2"
+                                Background="{TemplateBinding Background}"
+                                VerticalAlignment="Center" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SliderThumbStyle"
+           TargetType="Thumb">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Thumb">
+                    <Grid Width="18"
+                          Height="18">
+                        <Ellipse Fill="{DynamicResource SliderThumbBackgroundBrush}"
+                                 Stroke="{DynamicResource CardBorderBrush}"
+                                 StrokeThickness="1" />
+                        <Ellipse x:Name="Dot"
+                                 Width="10"
+                                 Height="10"
+                                 Fill="{DynamicResource AccentBrush}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Dot" Property="Width" Value="12" />
+                            <Setter TargetName="Dot" Property="Height" Value="12" />
+                        </Trigger>
+                        <Trigger Property="IsDragging" Value="True">
+                            <Setter TargetName="Dot" Property="Width" Value="8" />
+                            <Setter TargetName="Dot" Property="Height" Value="8" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style TargetType="{x:Type Slider}">
         <Setter Property="Margin" Value="0,0,0,4" />
+        <Setter Property="MinHeight" Value="22" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Slider}">
+                    <Grid VerticalAlignment="Center">
+                        <!-- Rail behind both repeat buttons; inset by half the thumb so it lines up with its center. -->
+                        <Border Height="4"
+                                CornerRadius="2"
+                                Background="{DynamicResource SliderTrackBrush}"
+                                VerticalAlignment="Center"
+                                Margin="8,0" />
+                        <Track x:Name="PART_Track">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource SliderTrackRepeatButton}"
+                                              Background="{DynamicResource AccentBrush}"
+                                              Command="{x:Static Slider.DecreaseLarge}" />
+                            </Track.DecreaseRepeatButton>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource SliderTrackRepeatButton}"
+                                              Background="Transparent"
+                                              Command="{x:Static Slider.IncreaseLarge}" />
+                            </Track.IncreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb Style="{StaticResource SliderThumbStyle}" />
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- ═══════════════════════════════════════════════════════════ -->
@@ -363,6 +653,101 @@
     <!-- ═══════════════════════════════════════════════════════════ -->
     <!-- Separator (within menus)                                    -->
     <!-- ═══════════════════════════════════════════════════════════ -->
+
+    <!-- ═══════════════════════════════════════════════════════════ -->
+    <!-- ScrollBar — thin Win11-style rail                           -->
+    <!-- ═══════════════════════════════════════════════════════════ -->
+
+    <Style x:Key="ScrollBarPageButton"
+           TargetType="RepeatButton">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <Border Background="Transparent" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ScrollBarThumbStyle"
+           TargetType="Thumb">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Thumb">
+                    <Border x:Name="ThumbBorder"
+                            Background="{DynamicResource ScrollBarThumbBrush}"
+                            CornerRadius="3"
+                            Margin="3"
+                            Opacity="0.7" />
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="ThumbBorder" Property="Opacity" Value="1" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type ScrollBar}">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Width" Value="12" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollBar}">
+                    <Grid Background="{TemplateBinding Background}">
+                        <Track x:Name="PART_Track"
+                               IsDirectionReversed="True">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource ScrollBarPageButton}"
+                                              Command="{x:Static ScrollBar.PageUpCommand}" />
+                            </Track.DecreaseRepeatButton>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource ScrollBarPageButton}"
+                                              Command="{x:Static ScrollBar.PageDownCommand}" />
+                            </Track.IncreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb Style="{StaticResource ScrollBarThumbStyle}" />
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="Orientation" Value="Horizontal">
+                <Setter Property="Width" Value="Auto" />
+                <Setter Property="Height" Value="12" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ScrollBar}">
+                            <Grid Background="{TemplateBinding Background}">
+                                <Track x:Name="PART_Track">
+                                    <Track.DecreaseRepeatButton>
+                                        <RepeatButton Style="{StaticResource ScrollBarPageButton}"
+                                                      Command="{x:Static ScrollBar.PageLeftCommand}" />
+                                    </Track.DecreaseRepeatButton>
+                                    <Track.IncreaseRepeatButton>
+                                        <RepeatButton Style="{StaticResource ScrollBarPageButton}"
+                                                      Command="{x:Static ScrollBar.PageRightCommand}" />
+                                    </Track.IncreaseRepeatButton>
+                                    <Track.Thumb>
+                                        <Thumb Style="{StaticResource ScrollBarThumbStyle}" />
+                                    </Track.Thumb>
+                                </Track>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
 
     <Style TargetType="{x:Type Separator}">
         <Setter Property="Height" Value="1" />

--- a/DesktopClock/Themes/HighContrastPalette.xaml
+++ b/DesktopClock/Themes/HighContrastPalette.xaml
@@ -1,0 +1,27 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- High-contrast palette — defers entirely to the user's chosen system colors. -->
+
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{DynamicResource {x:Static SystemColors.WindowColorKey}}" />
+    <SolidColorBrush x:Key="SubtleBrush" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{DynamicResource {x:Static SystemColors.WindowColorKey}}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{DynamicResource {x:Static SystemColors.ActiveBorderColorKey}}" />
+    <SolidColorBrush x:Key="SeparatorBrush" Color="{DynamicResource {x:Static SystemColors.ActiveBorderColorKey}}" />
+    <SolidColorBrush x:Key="TextPrimaryBrush" Color="{DynamicResource {x:Static SystemColors.WindowTextColorKey}}" />
+    <SolidColorBrush x:Key="TextSecondaryBrush" Color="{DynamicResource {x:Static SystemColors.GrayTextColorKey}}" />
+    <SolidColorBrush x:Key="HoverBrush" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
+    <SolidColorBrush x:Key="PressedBrush" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
+    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
+    <SolidColorBrush x:Key="ButtonBorderBrush" Color="{DynamicResource {x:Static SystemColors.ControlTextColorKey}}" />
+    <SolidColorBrush x:Key="ControlFillBrush" Color="{DynamicResource {x:Static SystemColors.WindowColorKey}}" />
+    <SolidColorBrush x:Key="ControlBorderBrush" Color="{DynamicResource {x:Static SystemColors.ControlTextColorKey}}" />
+    <SolidColorBrush x:Key="MenuBackgroundBrush" Color="{DynamicResource {x:Static SystemColors.MenuColorKey}}" />
+    <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="{DynamicResource {x:Static SystemColors.ControlTextColorKey}}" />
+    <SolidColorBrush x:Key="SliderTrackBrush" Color="{DynamicResource {x:Static SystemColors.ControlTextColorKey}}" />
+    <SolidColorBrush x:Key="SliderThumbBackgroundBrush" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
+
+    <SolidColorBrush x:Key="AccentBrush" Color="{DynamicResource {x:Static SystemColors.HighlightColorKey}}" />
+    <SolidColorBrush x:Key="OnAccentBrush" Color="{DynamicResource {x:Static SystemColors.HighlightTextColorKey}}" />
+
+</ResourceDictionary>

--- a/DesktopClock/Themes/LightPalette.xaml
+++ b/DesktopClock/Themes/LightPalette.xaml
@@ -1,0 +1,25 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Light palette — mirrors Windows 11 light mode surfaces. -->
+
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#F3F3F3" />
+    <SolidColorBrush x:Key="SubtleBrush" Color="#F5F5F5" />
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#E5E5E5" />
+    <SolidColorBrush x:Key="SeparatorBrush" Color="#E5E5E5" />
+    <SolidColorBrush x:Key="TextPrimaryBrush" Color="#1A1A1A" />
+    <SolidColorBrush x:Key="TextSecondaryBrush" Color="#5D5D5D" />
+    <SolidColorBrush x:Key="HoverBrush" Color="#EAEAEA" />
+    <SolidColorBrush x:Key="PressedBrush" Color="#E0E0E0" />
+    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#FBFBFB" />
+    <SolidColorBrush x:Key="ButtonBorderBrush" Color="#E0E0E0" />
+    <SolidColorBrush x:Key="ControlFillBrush" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ControlBorderBrush" Color="#DADADA" />
+    <SolidColorBrush x:Key="MenuBackgroundBrush" Color="#F9F9F9" />
+    <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="#9A9A9A" />
+
+    <!-- Fallback when the system accent can't be read; ThemeManager overrides at runtime. -->
+    <SolidColorBrush x:Key="AccentBrush" Color="#0067C0" />
+
+</ResourceDictionary>

--- a/DesktopClock/Themes/LightPalette.xaml
+++ b/DesktopClock/Themes/LightPalette.xaml
@@ -18,6 +18,11 @@
     <SolidColorBrush x:Key="ControlBorderBrush" Color="#DADADA" />
     <SolidColorBrush x:Key="MenuBackgroundBrush" Color="#F9F9F9" />
     <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="#9A9A9A" />
+    <SolidColorBrush x:Key="SliderTrackBrush" Color="#8A8A8A" />
+    <SolidColorBrush x:Key="SliderThumbBackgroundBrush" Color="#FFFFFF" />
+
+    <!-- Foreground for glyphs sitting on an accent fill. -->
+    <SolidColorBrush x:Key="OnAccentBrush" Color="#FFFFFF" />
 
     <!-- Fallback when the system accent can't be read; ThemeManager overrides at runtime. -->
     <SolidColorBrush x:Key="AccentBrush" Color="#0067C0" />

--- a/DesktopClock/Utilities/SystemThemeService.cs
+++ b/DesktopClock/Utilities/SystemThemeService.cs
@@ -42,6 +42,14 @@ public static class SystemThemeService
     }
 
     /// <summary>
+    /// Whether Windows is using the light app theme; defaults to light when it can't be read.
+    /// </summary>
+    public static bool IsLightTheme()
+    {
+        return !TryGetSystemThemeIsLight(out var isLight) || isLight;
+    }
+
+    /// <summary>
     /// Reads the light/dark preference from the Windows personalize key.
     /// </summary>
     private static bool TryGetSystemThemeIsLight(out bool isLightTheme)
@@ -68,7 +76,7 @@ public static class SystemThemeService
     /// <summary>
     /// Resolves the current accent color using DWM, registry, then system parameters.
     /// </summary>
-    private static Color GetSystemAccentColor()
+    public static Color GetSystemAccentColor()
     {
         // Prefer DWM because it tracks the active colorization value.
         if (TryGetAccentColorFromDwm(out var accent) || TryGetAccentColorFromRegistry(out accent))

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -19,6 +19,7 @@ public static class ThemeManager
 
     private static readonly Uri LightPaletteUri = new(PaletteFolder + "LightPalette.xaml", UriKind.Relative);
     private static readonly Uri DarkPaletteUri = new(PaletteFolder + "DarkPalette.xaml", UriKind.Relative);
+    private static readonly Uri HighContrastPaletteUri = new(PaletteFolder + "HighContrastPalette.xaml", UriKind.Relative);
 
     /// <summary>
     /// Whether the dark palette is currently applied.
@@ -64,7 +65,11 @@ public static class ThemeManager
 
     private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
     {
-        if (e.Category != UserPreferenceCategory.General)
+        // Theme changes arrive as General; accent and high-contrast changes as Color/VisualStyle/Accessibility.
+        if (e.Category is not (UserPreferenceCategory.General
+            or UserPreferenceCategory.Color
+            or UserPreferenceCategory.VisualStyle
+            or UserPreferenceCategory.Accessibility))
             return;
 
         Application.Current?.Dispatcher.BeginInvoke(new Action(Apply));
@@ -76,9 +81,11 @@ public static class ThemeManager
         if (app == null)
             return;
 
-        IsDarkTheme = !SystemThemeService.IsLightTheme();
+        var highContrast = SystemParameters.HighContrast;
+        IsDarkTheme = !highContrast && !SystemThemeService.IsLightTheme();
 
-        var paletteUri = IsDarkTheme ? DarkPaletteUri : LightPaletteUri;
+        var paletteUri = highContrast ? HighContrastPaletteUri :
+            IsDarkTheme ? DarkPaletteUri : LightPaletteUri;
         var palette = new ResourceDictionary { Source = paletteUri };
 
         var dictionaries = app.Resources.MergedDictionaries;
@@ -89,7 +96,11 @@ public static class ThemeManager
         else
             dictionaries.Add(palette);
 
-        app.Resources["AccentBrush"] = CreateAccentBrush();
+        // In high contrast the palette's system highlight color wins; otherwise use the accent color.
+        if (highContrast)
+            app.Resources.Remove("AccentBrush");
+        else
+            app.Resources["AccentBrush"] = CreateAccentBrush();
 
         foreach (Window window in app.Windows)
             ApplyTitleBarTheme(window);

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using Microsoft.Win32;
+
+namespace DesktopClock.Utilities;
+
+/// <summary>
+/// Applies the light or dark UI palette and keeps it in sync with the Windows theme and accent color.
+/// </summary>
+public static class ThemeManager
+{
+    private const string PaletteFolder = "Themes/";
+    private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+    private const int DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19;
+
+    private static readonly Uri LightPaletteUri = new(PaletteFolder + "LightPalette.xaml", UriKind.Relative);
+    private static readonly Uri DarkPaletteUri = new(PaletteFolder + "DarkPalette.xaml", UriKind.Relative);
+
+    /// <summary>
+    /// Whether the dark palette is currently applied.
+    /// </summary>
+    public static bool IsDarkTheme { get; private set; }
+
+    /// <summary>
+    /// Raised after the palette has been swapped for a new system theme.
+    /// </summary>
+    public static event EventHandler ThemeChanged;
+
+    /// <summary>
+    /// Applies the palette matching the current system theme and follows future changes.
+    /// </summary>
+    public static void Initialize()
+    {
+        Apply();
+        SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
+    }
+
+    /// <summary>
+    /// Makes the window's title bar match the current theme (dark or light).
+    /// </summary>
+    public static void ApplyTitleBarTheme(Window window)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero)
+            return;
+
+        var useDark = IsDarkTheme ? 1 : 0;
+
+        try
+        {
+            // Try the documented attribute first, then the pre-20H1 value for older Windows 10 builds.
+            if (DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ref useDark, sizeof(int)) != 0)
+                DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1, ref useDark, sizeof(int));
+        }
+        catch
+        {
+            // DWM isn't available; keep the default title bar.
+        }
+    }
+
+    private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
+    {
+        if (e.Category != UserPreferenceCategory.General)
+            return;
+
+        Application.Current?.Dispatcher.BeginInvoke(new Action(Apply));
+    }
+
+    private static void Apply()
+    {
+        var app = Application.Current;
+        if (app == null)
+            return;
+
+        IsDarkTheme = !SystemThemeService.IsLightTheme();
+
+        var paletteUri = IsDarkTheme ? DarkPaletteUri : LightPaletteUri;
+        var palette = new ResourceDictionary { Source = paletteUri };
+
+        var dictionaries = app.Resources.MergedDictionaries;
+        var existingPalette = dictionaries.FirstOrDefault(d => d.Source?.OriginalString.Contains("Palette.xaml") == true);
+
+        if (existingPalette != null)
+            dictionaries[dictionaries.IndexOf(existingPalette)] = palette;
+        else
+            dictionaries.Add(palette);
+
+        app.Resources["AccentBrush"] = CreateAccentBrush();
+
+        foreach (Window window in app.Windows)
+            ApplyTitleBarTheme(window);
+
+        ThemeChanged?.Invoke(null, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Builds the accent brush from the system accent color, lightened in dark mode for contrast.
+    /// </summary>
+    private static SolidColorBrush CreateAccentBrush()
+    {
+        var accent = SystemThemeService.GetSystemAccentColor();
+
+        if (IsDarkTheme)
+            accent = Lighten(accent, 0.45);
+
+        var brush = new SolidColorBrush(accent);
+        brush.Freeze();
+        return brush;
+    }
+
+    private static Color Lighten(Color color, double amount)
+    {
+        return Color.FromRgb(
+            (byte)(color.R + (255 - color.R) * amount),
+            (byte)(color.G + (255 - color.G) * amount),
+            (byte)(color.B + (255 - color.B) * amount));
+    }
+
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+}

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -70,7 +70,9 @@ public static class ThemeManager
             or UserPreferenceCategory.Color
             or UserPreferenceCategory.VisualStyle
             or UserPreferenceCategory.Accessibility))
+        {
             return;
+        }
 
         Application.Current?.Dispatcher.BeginInvoke(new Action(Apply));
     }
@@ -126,9 +128,9 @@ public static class ThemeManager
     private static Color Lighten(Color color, double amount)
     {
         return Color.FromRgb(
-            (byte)(color.R + (255 - color.R) * amount),
-            (byte)(color.G + (255 - color.G) * amount),
-            (byte)(color.B + (255 - color.B) * amount));
+            (byte)(color.R + ((255 - color.R) * amount)),
+            (byte)(color.G + ((255 - color.G) * amount)),
+            (byte)(color.B + ((255 - color.B) * amount)));
     }
 
     [DllImport("dwmapi.dll", PreserveSig = true)]


### PR DESCRIPTION
Rethemes the context menu and settings window to a modern Windows 11 look. The previous theme was light-only and all-neutral grey, and half the controls still rendered their Aero-era defaults.

- **Dark mode that follows Windows** — color tokens moved out of `FluentTheme.xaml` into `LightPalette`/`DarkPalette` dictionaries. A new `ThemeManager` applies the palette matching `AppsUseLightTheme` at startup, swaps it live on theme changes, and darkens the settings window title bar via DWM.
- **System accent color put to work** — seeded from DWM (lightened in dark mode for contrast) and used for the sidebar selection pill, checkbox fills, slider tracks/thumbs, combo box selection pills, menu checkmarks, and focus borders. Accent changes propagate live.
- **Fluent templates for the remaining stock controls** — CheckBox, Slider, ComboBox (+ dropdown), TextBox, ScrollBar, and ToolTip; all rounded, palette-aware, and hover/focus-themed.
- **Settings sidebar polish** — the grey slab and divider are gone (nav sits on the window background like Win11 Settings), and the section currently in view is marked with an accent pill that tracks the scroll position.
- **Context menu icons** — the MenuItem template's icon column was permanently collapsed (pre-existing bug); it's enabled now with Segoe Fluent Icons glyphs (MDL2 fallback on Win10).
- **High-contrast support restored** — a `HighContrastPalette` defers entirely to system colors whenever Windows high contrast is active, preserving the accessibility intent of the old `SystemColors`-based brushes.

<img width="660" height="450" alt="image" src="https://github.com/user-attachments/assets/648bcd8b-cd45-46a4-b667-5bc5e878235c" />

<img width="1417" height="918" alt="image" src="https://github.com/user-attachments/assets/d9a1b4ea-78fd-4ff5-b432-c39e9da089bc" />

<img width="683" height="498" alt="image" src="https://github.com/user-attachments/assets/86f01330-7a61-40b1-aca5-d4606c49d02a" />


<img width="1417" height="918" alt="image" src="https://github.com/user-attachments/assets/df9be653-bead-4d8f-bb11-ac8de5bef316" />
