### PR TITLE
Stop TimeZoneNotFoundException from being thrown every tick

### DIFF
--- a/DesktopClock/Properties/Settings.cs
+++ b/DesktopClock/Properties/Settings.cs
@@ -11,11 +11,8 @@ namespace DesktopClock.Properties;
 public sealed class Settings : INotifyPropertyChanged, IDisposable
 {
     private readonly FileSystemWatcher _watcher;
-
-    // Cached result of resolving <see cref="TimeZone"/> so repeated reads don't hit the registry.
     private string _resolvedTimeZoneId;
     private TimeZoneInfo _resolvedTimeZone;
-
     private static readonly Lazy<Settings> _default = new(LoadAndAttemptSave);
 
     private static readonly JsonSerializerSettings _jsonSerializerSettings = new()
@@ -396,13 +393,11 @@ public sealed class Settings : INotifyPropertyChanged, IDisposable
     {
         get
         {
-            // An empty ID means "use the system time zone" and is the default,
-            // so don't pay for a failed registry lookup on every call.
+            // An empty ID means "use the system time zone" and is the default, so don't pay for a failed registry lookup on every call.
             if (string.IsNullOrWhiteSpace(TimeZone))
                 return TimeZoneInfo.Local;
 
-            // Cache the lookup; this getter can run every second and an unknown
-            // or corrupt ID would otherwise throw on each tick.
+            // Cache the lookup; this getter can run every second and an unknown or corrupt ID would otherwise throw on each tick.
             if (_resolvedTimeZoneId != TimeZone)
             {
                 try

--- a/DesktopClock/Properties/Settings.cs
+++ b/DesktopClock/Properties/Settings.cs
@@ -12,6 +12,10 @@ public sealed class Settings : INotifyPropertyChanged, IDisposable
 {
     private readonly FileSystemWatcher _watcher;
 
+    // Cached result of resolving <see cref="TimeZone"/> so repeated reads don't hit the registry.
+    private string _resolvedTimeZoneId;
+    private TimeZoneInfo _resolvedTimeZone;
+
     private static readonly Lazy<Settings> _default = new(LoadAndAttemptSave);
 
     private static readonly JsonSerializerSettings _jsonSerializerSettings = new()
@@ -392,14 +396,28 @@ public sealed class Settings : INotifyPropertyChanged, IDisposable
     {
         get
         {
-            try
-            {
-                return TimeZoneInfo.FindSystemTimeZoneById(TimeZone);
-            }
-            catch (TimeZoneNotFoundException)
-            {
+            // An empty ID means "use the system time zone" and is the default,
+            // so don't pay for a failed registry lookup on every call.
+            if (string.IsNullOrWhiteSpace(TimeZone))
                 return TimeZoneInfo.Local;
+
+            // Cache the lookup; this getter can run every second and an unknown
+            // or corrupt ID would otherwise throw on each tick.
+            if (_resolvedTimeZoneId != TimeZone)
+            {
+                try
+                {
+                    _resolvedTimeZone = TimeZoneInfo.FindSystemTimeZoneById(TimeZone);
+                }
+                catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
+                {
+                    _resolvedTimeZone = TimeZoneInfo.Local;
+                }
+
+                _resolvedTimeZoneId = TimeZone;
             }
+
+            return _resolvedTimeZone;
         }
         set
         {


### PR DESCRIPTION
`Settings.TimeZoneInfo` no longer relies on a caught `TimeZoneNotFoundException` as its normal fallback path:

- An empty/whitespace `TimeZone` ID (the default) now returns `TimeZoneInfo.Local` directly without calling `FindSystemTimeZoneById`.
- The resolved zone is cached against the ID that produced it, so a genuinely unknown ID throws once and reuses the fallback afterward. Changing the time zone (settings UI or an external settings-file edit) invalidates the cache since the stored ID no longer matches.
- The fallback also covers `InvalidTimeZoneException`, which `FindSystemTimeZoneById` can throw for corrupt registry data.

`TimeZone` defaults to an empty string, so every read of `Settings.Default.TimeZoneInfo` threw and swallowed a `TimeZoneNotFoundException`. The main window caches its zone, but the format editor added in #140 refreshes its preview on a 1-second `DispatcherTimer` and reads the property each time — producing `Exception thrown: 'System.TimeZoneNotFoundException' in mscorlib.dll` in the debug output on every tick.