### PR TITLE
Add ISO week number tokens to the clock format

### DIFF
--- a/DesktopClock.Tests/DateTimeTests.cs
+++ b/DesktopClock.Tests/DateTimeTests.cs
@@ -144,6 +144,22 @@ public class DateTimeTests
     }
 
     [Theory]
+    [InlineData("2024-01-01", 1, 2024)] // Monday starting the first ISO week of 2024.
+    [InlineData("2024-12-29", 52, 2024)] // Sunday ending the last ISO week of 2024.
+    [InlineData("2024-12-30", 1, 2025)] // Monday belonging to the first ISO week of 2025.
+    [InlineData("2021-01-01", 53, 2020)] // Friday belonging to the last ISO week of 2020.
+    [InlineData("2026-07-06", 28, 2026)] // Mid-year date where week year matches calendar year.
+    public void GetIsoWeek_MatchesIso8601(string dateString, int expectedWeek, int expectedWeekYear)
+    {
+        // Arrange
+        var date = DateTime.Parse(dateString, CultureInfo.InvariantCulture);
+
+        // Act & Assert
+        Assert.Equal(expectedWeek, date.GetIsoWeekOfYear());
+        Assert.Equal(expectedWeekYear, date.GetIsoWeekYear());
+    }
+
+    [Theory]
     [InlineData("dddd, MMMM dd", "Monday, January 01")]
     [InlineData("yyyy-MM-dd", "2024-01-01")]
     [InlineData("HH:mm:ss", "00:00:00")]

--- a/DesktopClock.Tests/TimeStringFormatterTests.cs
+++ b/DesktopClock.Tests/TimeStringFormatterTests.cs
@@ -134,6 +134,25 @@ public class TimeStringFormatterTests
     }
 
     [Fact]
+    public void Format_WeekTokenUsesSelectedTimeZone()
+    {
+        // 23:30 UTC on Sunday is already Monday of ISO week 1 in a UTC+2 zone.
+        var now = new DateTimeOffset(2024, 12, 29, 23, 30, 0, TimeSpan.Zero);
+        var timeZone = TimeZoneInfo.CreateCustomTimeZone("UtcPlus2", TimeSpan.FromHours(2), "UtcPlus2", "UtcPlus2");
+
+        var result = TimeStringFormatter.Format(
+            now,
+            now.DateTime,
+            timeZone,
+            default,
+            "{weekYear}-W{week}",
+            null,
+            CultureInfo.InvariantCulture);
+
+        Assert.Equal("2025-W1", result);
+    }
+
+    [Fact]
     public void Format_InvalidClockFormatShowsBriefErrorMessage()
     {
         var now = new DateTimeOffset(2024, 1, 1, 10, 15, 0, TimeSpan.Zero);

--- a/DesktopClock.Tests/TokenizerTests.cs
+++ b/DesktopClock.Tests/TokenizerTests.cs
@@ -111,6 +111,69 @@ public class TokenizerTests
         Assert.Equal("Sunday, Sep 24", result);
     }
 
+    [Theory]
+    [InlineData("2024-01-01", "Week 1")]
+    [InlineData("2024-12-29", "Week 52")]
+    [InlineData("2024-12-30", "Week 1")]
+    [InlineData("2021-01-01", "Week 53")]
+    public void FormatWithTokenizer_WeekToken_ShouldUseIsoWeek(string dateString, string expected)
+    {
+        // Arrange
+        var dateTime = DateTime.Parse(dateString, CultureInfo.InvariantCulture);
+        var format = "Week {week}";
+
+        // Act
+        var result = Tokenizer.FormatWithTokenizerOrFallBack(dateTime, format, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("2024-12-30", "2025-W1")]
+    [InlineData("2021-01-01", "2020-W53")]
+    [InlineData("2026-05-06", "2026-W19")]
+    public void FormatWithTokenizer_WeekYearToken_ShouldUseIsoWeekYear(string dateString, string expected)
+    {
+        // Arrange
+        var dateTime = DateTime.Parse(dateString, CultureInfo.InvariantCulture);
+        var format = "{weekYear}-W{week}";
+
+        // Act
+        var result = Tokenizer.FormatWithTokenizerOrFallBack(dateTime, format, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void FormatWithTokenizer_WeekToken_MixesWithStandardTokens()
+    {
+        // Arrange
+        var dateTimeOffset = new DateTimeOffset(2024, 12, 30, 14, 30, 0, TimeSpan.Zero);
+        var format = "{ddd}, {MMM dd} (W{week})";
+
+        // Act
+        var result = Tokenizer.FormatWithTokenizerOrFallBack(dateTimeOffset, format, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal("Mon, Dec 30 (W1)", result);
+    }
+
+    [Fact]
+    public void FormatWithTokenizer_WeekToken_OnTimeSpan_ShowsErrorMessage()
+    {
+        // Arrange - week tokens only apply to dates, so a countdown format using one is invalid.
+        var timeSpan = new TimeSpan(1, 2, 3, 4);
+        var format = "Week {week}";
+
+        // Act
+        var result = Tokenizer.FormatWithTokenizerOrFallBack(timeSpan, format, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal(Tokenizer.FormatErrorMessage, result);
+    }
+
     [Fact]
     public void FormatWithTokenizer_StandardFormat_WithoutBraces_ShouldWork()
     {

--- a/DesktopClock/FormatEditor.xaml.cs
+++ b/DesktopClock/FormatEditor.xaml.cs
@@ -33,6 +33,7 @@ public partial class FormatEditor : UserControl
         ("Full date and time", "{dddd}, {MMMM dd}, {h:mm tt}"),
         ("Date only", "{dddd}, {MMMM dd}"),
         ("Sortable", "{yyyy-MM-dd} {HH:mm}"),
+        ("ISO week", "{weekYear}-W{week}"),
     };
 
     private static readonly (string Name, string Format)[] CountdownPresets =

--- a/DesktopClock/FormatEditor.xaml.cs
+++ b/DesktopClock/FormatEditor.xaml.cs
@@ -57,6 +57,7 @@ public partial class FormatEditor : UserControl
         ("Time", "{h:mm tt}"),
         ("Time (24-hour)", "{HH:mm}"),
         ("Seconds", "{ss}"),
+        ("Week number", "{week}"),
         ("UTC offset", "{zzz}"),
     };
 

--- a/DesktopClock/Utilities/DateFormatExample.cs
+++ b/DesktopClock/Utilities/DateFormatExample.cs
@@ -58,7 +58,9 @@ public record DateFormatExample
         "{dddd}, {MMM dd}, {h:mm tt}",        // Custom format: "Monday, Apr 10, 2:30 PM"
         "{dddd}, {MMM dd}, {HH:mm:ss}",       // Custom format: "Monday, Apr 10, 14:30:45"
         "{dddd}, {MMM dd}, {h:mm:ss tt}",     // Custom format: "Monday, Apr 10, 2:30:45 PM"
-    
+        "Week {week}",                        // Custom token: "Week 15"
+        "{weekYear}-W{week}",                 // Custom tokens: "2023-W15" (ISO week date)
+
         // Standard formats
         "D",                                  // Long date pattern: Monday, June 15, 2009 (en-US)
         "f",                                  // Full date/time pattern (short time): Monday, June 15, 2009 1:45 PM (en-US)

--- a/DesktopClock/Utilities/DateTimeUtil.cs
+++ b/DesktopClock/Utilities/DateTimeUtil.cs
@@ -1,9 +1,34 @@
 ﻿using System;
+using System.Globalization;
 
 namespace DesktopClock;
 
 public static class DateTimeUtil
 {
+    /// <summary>
+    /// Gets the ISO 8601 week number (1-53) for the given date.
+    /// Equivalent to <c>ISOWeek.GetWeekOfYear</c>, which isn't available on .NET Framework.
+    /// </summary>
+    public static int GetIsoWeekOfYear(this DateTime date)
+    {
+        // ISO weeks start on Monday and belong to the year containing their Thursday,
+        // so shift Monday through Wednesday forward to get counted in the correct week.
+        if (date.DayOfWeek >= DayOfWeek.Monday && date.DayOfWeek <= DayOfWeek.Wednesday)
+            date = date.AddDays(3);
+
+        return CultureInfo.InvariantCulture.Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday);
+    }
+
+    /// <summary>
+    /// Gets the ISO 8601 week-numbering year for the given date,
+    /// which differs from the calendar year for days near New Year.
+    /// </summary>
+    public static int GetIsoWeekYear(this DateTime date)
+    {
+        var dayOfWeek = date.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)date.DayOfWeek;
+        return date.AddDays(4 - dayOfWeek).Year;
+    }
+
     public static bool EqualExcludingMillisecond(this DateTime dt1, DateTime dt2)
     {
         if (dt1.Year != dt2.Year)

--- a/DesktopClock/Utilities/DateTimeUtil.cs
+++ b/DesktopClock/Utilities/DateTimeUtil.cs
@@ -11,8 +11,7 @@ public static class DateTimeUtil
     /// </summary>
     public static int GetIsoWeekOfYear(this DateTime date)
     {
-        // ISO weeks start on Monday and belong to the year containing their Thursday,
-        // so shift Monday through Wednesday forward to get counted in the correct week.
+        // ISO weeks start on Monday and belong to the year containing their Thursday, so shift Monday through Wednesday forward to get counted in the correct week.
         if (date.DayOfWeek >= DayOfWeek.Monday && date.DayOfWeek <= DayOfWeek.Wednesday)
             date = date.AddDays(3);
 
@@ -20,8 +19,7 @@ public static class DateTimeUtil
     }
 
     /// <summary>
-    /// Gets the ISO 8601 week-numbering year for the given date,
-    /// which differs from the calendar year for days near New Year.
+    /// Gets the ISO 8601 week-numbering year for the given date, which differs from the calendar year for days near New Year.
     /// </summary>
     public static int GetIsoWeekYear(this DateTime date)
     {

--- a/DesktopClock/Utilities/Tokenizer.cs
+++ b/DesktopClock/Utilities/Tokenizer.cs
@@ -31,6 +31,12 @@ public static class Tokenizer
                     return _tokenizerRegex.Replace(format, (m) =>
                     {
                         var formatString = m.Groups[1].Value;
+
+                        if (TryFormatCustomToken(formattable, formatString, formatProvider, out var customResult))
+                        {
+                            return customResult;
+                        }
+
                         return formattable.ToString(formatString, formatProvider);
                     });
                 }
@@ -46,6 +52,29 @@ public static class Tokenizer
 
         // Fall back to the default format.
         return formattable.ToString();
+    }
+
+    /// <summary>
+    /// Handles tokens that have no standard format string equivalent, such as ISO week numbers.
+    /// </summary>
+    private static bool TryFormatCustomToken(IFormattable formattable, string token, IFormatProvider formatProvider, out string result)
+    {
+        result = null;
+
+        if (token != "week" && token != "weekYear")
+            return false;
+
+        DateTime dateTime;
+        if (formattable is DateTime dt)
+            dateTime = dt;
+        else if (formattable is DateTimeOffset dto)
+            dateTime = dto.DateTime;
+        else
+            return false;
+
+        var value = token == "week" ? dateTime.GetIsoWeekOfYear() : dateTime.GetIsoWeekYear();
+        result = value.ToString(formatProvider);
+        return true;
     }
 
     private static bool UsesTokenSyntax(string format)


### PR DESCRIPTION
Adds `{week}` (ISO 8601 week number) and `{weekYear}` (ISO week-numbering year) as custom clock format tokens, so formats like `Week {week}` or `{weekYear}-W{week}` work in the clock display.

Supersedes #130 (thanks @spacevortex2435 for the groundwork! token names and several test cases carry over):
- The ISO week math lives in `DateTimeUtil` as documented extension methods instead of private helpers inside the tokenizer (`ISOWeek` isn't available on .NET Framework, so it's hand-rolled with the same semantics).
- The tokens are discoverable: a **Week number** insert button in the inline format editor (#140) and examples in the format list.
- A countdown format using `{week}` shows the standard "Bad format" error instead of throwing, with a test covering it.

Details
- Week numbers respect the selected time zone since conversion happens before formatting (test included).
- Number output uses the active format provider like every other token.
- Around New Year, `{weekYear}` differs from `{yyyy}` per ISO 8601 — e.g. Dec 30, 2024 is `2025-W1`.

Closes #130
Closes #107
Closes #78

<img width="1920" height="1023" alt="image" src="https://github.com/user-attachments/assets/d49e5ec2-b53e-4753-967e-98a0e91cc731" />