### PR TITLE
Stop the settings window from flashing white on open

### DIFF
--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -27,6 +27,7 @@ public partial class SettingsWindow : Window
         InitializeComponent();
         DataContext = new SettingsWindowViewModel(Settings.Default);
         Closing += SettingsWindow_Closing;
+        Utilities.ThemeManager.HideUntilContentRendered(this);
     }
 
     private SettingsWindowViewModel ViewModel => (SettingsWindowViewModel)DataContext;

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
+using System.Windows.Threading;
 using Microsoft.Win32;
 
 namespace DesktopClock.Utilities;
@@ -16,6 +18,7 @@ public static class ThemeManager
     private const string PaletteFolder = "Themes/";
     private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
     private const int DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19;
+    private const int DWMWA_CLOAK = 13;
 
     private static readonly Uri LightPaletteUri = new(PaletteFolder + "LightPalette.xaml", UriKind.Relative);
     private static readonly Uri DarkPaletteUri = new(PaletteFolder + "DarkPalette.xaml", UriKind.Relative);
@@ -60,6 +63,76 @@ public static class ThemeManager
         catch
         {
             // DWM isn't available; keep the default title bar.
+        }
+    }
+
+    /// <summary>
+    /// Keeps the window invisible until its first frame has rendered, so it can't flash
+    /// as an unpainted white rectangle before WPF draws the themed content.
+    /// </summary>
+    /// <remarks>
+    /// The window's surface starts out white and DWM shows it as soon as the window opens,
+    /// which reads as a bright flash in dark mode. Cloaking hides the window at the DWM level
+    /// (unlike <see cref="Window.Visibility"/>, it doesn't affect layout, activation, or focus)
+    /// until the content is actually on the surface.
+    /// </remarks>
+    public static void HideUntilContentRendered(Window window)
+    {
+        window.SourceInitialized += (_, _) => SetCloaked(window, true);
+
+        // ContentRendered fires when the frame is handed to the render thread, slightly
+        // before it reaches the screen surface, so wait out the render and composition
+        // passes that carry the frame before revealing the window.
+        window.ContentRendered += (_, _) => window.Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(() =>
+        {
+            WaitForRenderThread(window.Dispatcher);
+
+            try
+            {
+                DwmFlush();
+            }
+            catch
+            {
+            }
+
+            SetCloaked(window, false);
+        }));
+    }
+
+    /// <summary>
+    /// Blocks until the render thread has finished presenting the current frame.
+    /// </summary>
+    private static void WaitForRenderThread(Dispatcher dispatcher)
+    {
+        // MediaContext.CompleteRender is what WPF itself uses to sync with the render
+        // thread but it isn't public; if the internals ever change, the cloaked window
+        // just reveals a frame early.
+        try
+        {
+            var mediaContextType = typeof(CompositionTarget).Assembly.GetType("System.Windows.Media.MediaContext");
+            var mediaContext = mediaContextType?.GetMethod("From", BindingFlags.Static | BindingFlags.NonPublic)?.Invoke(null, [dispatcher]);
+            mediaContextType?.GetMethod("CompleteRender", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)?.Invoke(mediaContext, null);
+        }
+        catch
+        {
+        }
+    }
+
+    private static void SetCloaked(Window window, bool cloaked)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero)
+            return;
+
+        var value = cloaked ? 1 : 0;
+
+        try
+        {
+            DwmSetWindowAttribute(hwnd, DWMWA_CLOAK, ref value, sizeof(int));
+        }
+        catch
+        {
+            // DWM isn't available; the window just shows normally.
         }
     }
 
@@ -135,4 +208,7 @@ public static class ThemeManager
 
     [DllImport("dwmapi.dll", PreserveSig = true)]
     private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmFlush();
 }


### PR DESCRIPTION
## Problem

Since the Windows 11 retheme (#138), opening the settings window flashes a bright white rectangle before the dark content appears. The flash has always been there — a WPF window's surface is white until the first frame is presented, and DWM shows the window (with its open animation) as soon as it exists. Before dark mode the content was light so the white surface was invisible; now it reads as a broken, delayed load.

Measured by sampling the screen pixel at the window's center every ~10 ms while opening (Debug build):

**Before** — the open animation fades in a pure white surface, which stays up for ~130 ms before content lands:

| time | color |
|---|---|
| 0–100 ms | desktop |
| 107–180 ms | fade to `#FFFFFF` |
| 180–311 ms | solid white ⚠️ |
| 311 ms | dark content |

**After** — no white frame is ever visible; the window appears fully rendered:

| time | color |
|---|---|
| 0–320 ms | desktop |
| 320 ms | dark content |

## Fix

`ThemeManager.HideUntilContentRendered` cloaks the window at the DWM level (`DWMWA_CLOAK`) from `SourceInitialized` until its first frame is actually on the surface, then reveals it. Unlike `Visibility`/`Opacity`, cloaking doesn't affect layout, activation, or focus, and needs no `AllowsTransparency`.

`ContentRendered` alone isn't enough — it fires when the frame is handed to the render thread, ~50 ms before it reaches the surface, which still left a white sliver. So the reveal waits for an idle dispatcher, syncs with the render thread (`MediaContext.CompleteRender`, the same sync WPF uses internally; wrapped in try/catch so a future WPF change just means revealing a frame early), and flushes a DWM composition pass.

Everything degrades gracefully: if DWM or the reflection call is unavailable, the window simply shows the way it does today.

## Notes on load time

- Warm reopen is ~115 ms click-to-frame; the first open per session is ~330 ms (Debug), dominated by layout of the settings page (~180 ms) and the one-time font enumeration for the Typography section (~85 ms).
- The window now appears once, fully formed, instead of white-then-content in two stages — that two-stage paint was most of the "delayed load" feel.

Verified with a scratchpad harness that samples screen pixels during open (5 runs, zero white frames) and renders the window to PNG to confirm appearance is unchanged.