### PR TITLE
Improve settings window load performance

### DIFF
--- a/DesktopClock/App.xaml.cs
+++ b/DesktopClock/App.xaml.cs
@@ -20,6 +20,12 @@ public partial class App : Application
     {
         base.OnStartup(e);
         ThemeManager.Initialize();
+
+        // Warm the settings window's system lists once the clock is up and idle,
+        // so opening settings later doesn't stall on enumerating them.
+        Dispatcher.BeginInvoke(
+            System.Windows.Threading.DispatcherPriority.ApplicationIdle,
+            new Action(SettingsWindowViewModel.PrefetchSystemLists));
     }
 
     /// <summary>

--- a/DesktopClock/App.xaml.cs
+++ b/DesktopClock/App.xaml.cs
@@ -21,8 +21,7 @@ public partial class App : Application
         base.OnStartup(e);
         ThemeManager.Initialize();
 
-        // Warm the settings window's system lists once the clock is up and idle,
-        // so opening settings later doesn't stall on enumerating them.
+        // Warm the settings window's system lists once the clock is up and idle, so opening settings later doesn't stall on enumerating them.
         Dispatcher.BeginInvoke(
             System.Windows.Threading.DispatcherPriority.ApplicationIdle,
             new Action(SettingsWindowViewModel.PrefetchSystemLists));

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Drawing.Text;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -323,6 +324,14 @@ public static class NavButton
 
 public partial class SettingsWindowViewModel : ObservableObject
 {
+    // Enumerating fonts and time zones costs ~100 ms and the results don't change within
+    // a session, so they're fetched once on a background thread. The app kicks this off
+    // while idle after startup so opening settings doesn't have to pay for it.
+    private static readonly Lazy<Task<(IList<string> Fonts, IList<TimeZoneInfo> TimeZones)>> _systemLists =
+        new(() => Task.Run(() => (
+            (IList<string>)GetAllSystemFonts().Distinct().OrderBy(f => f).ToList(),
+            (IList<TimeZoneInfo>)TimeZoneInfo.GetSystemTimeZones())));
+
     public Settings Settings { get; }
 
     /// <summary>
@@ -334,17 +343,21 @@ public partial class SettingsWindowViewModel : ObservableObject
     {
         Settings = settings;
         AppVersion = FileVersionInfo.GetVersionInfo(App.MainFileInfo.FullName).FileVersion;
-        FontFamilies = GetAllSystemFonts().Distinct().OrderBy(f => f).ToList();
         FontStyles = ["Normal", "Italic", "Oblique"];
         FontWeights = ["Thin", "ExtraLight", "Light", "Normal", "Medium", "SemiBold", "Bold", "ExtraBold", "Black", "ExtraBlack"];
         ImageStretches = Enum.GetValues(typeof(Stretch)).Cast<Stretch>().ToArray();
-        TimeZones = TimeZoneInfo.GetSystemTimeZones();
     }
+
+    /// <summary>
+    /// Starts fetching the system lists in the background so they're ready by the time
+    /// the settings window binds to them.
+    /// </summary>
+    public static void PrefetchSystemLists() => _ = _systemLists.Value;
 
     /// <summary>
     /// All available font families reported by the system.
     /// </summary>
-    public IList<string> FontFamilies { get; }
+    public IList<string> FontFamilies => _systemLists.Value.Result.Fonts;
 
     /// <summary>
     /// All available font styles.
@@ -364,7 +377,7 @@ public partial class SettingsWindowViewModel : ObservableObject
     /// <summary>
     /// All available time zones reported by the system.
     /// </summary>
-    public IList<TimeZoneInfo> TimeZones { get; }
+    public IList<TimeZoneInfo> TimeZones => _systemLists.Value.Result.TimeZones;
 
     /// <summary>
     /// Sets the format string in settings.
@@ -420,7 +433,7 @@ public partial class SettingsWindowViewModel : ObservableObject
         Settings.BackgroundImagePath = string.Empty;
     }
 
-    private IEnumerable<string> GetAllSystemFonts()
+    private static IEnumerable<string> GetAllSystemFonts()
     {
         // Get fonts from WPF.
         foreach (var fontFamily in Fonts.SystemFontFamilies)

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -27,7 +27,6 @@ public partial class SettingsWindow : Window
         InitializeComponent();
         DataContext = new SettingsWindowViewModel(Settings.Default);
         Closing += SettingsWindow_Closing;
-        Utilities.ThemeManager.HideUntilContentRendered(this);
     }
 
     private SettingsWindowViewModel ViewModel => (SettingsWindowViewModel)DataContext;

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -325,9 +325,7 @@ public static class NavButton
 
 public partial class SettingsWindowViewModel : ObservableObject
 {
-    // Enumerating fonts and time zones costs ~100 ms and the results don't change within
-    // a session, so they're fetched once on a background thread. The app kicks this off
-    // while idle after startup so opening settings doesn't have to pay for it.
+    // Enumerating fonts and time zones costs ~100 ms and the results don't change within a session, so they're fetched once on a background thread that the app kicks off while idle after startup.
     private static readonly Lazy<Task<(IList<string> Fonts, IList<TimeZoneInfo> TimeZones)>> _systemLists =
         new(() => Task.Run(() => (
             (IList<string>)GetAllSystemFonts().Distinct().OrderBy(f => f).ToList(),
@@ -350,8 +348,7 @@ public partial class SettingsWindowViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Starts fetching the system lists in the background so they're ready by the time
-    /// the settings window binds to them.
+    /// Starts fetching the system lists in the background so they're ready by the time the settings window binds to them.
     /// </summary>
     public static void PrefetchSystemLists() => _ = _systemLists.Value;
 

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -35,6 +35,7 @@ public partial class SettingsWindow : Window
     private void Window_SourceInitialized(object sender, EventArgs e)
     {
         Utilities.ThemeManager.ApplyTitleBarTheme(this);
+        Utilities.ThemeManager.ApplyThemedBackgroundErase(this);
     }
 
     private void BrowseBackgroundImagePath(object sender, RoutedEventArgs e)

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -27,6 +27,7 @@ public partial class SettingsWindow : Window
         InitializeComponent();
         DataContext = new SettingsWindowViewModel(Settings.Default);
         Closing += SettingsWindow_Closing;
+        Utilities.ThemeManager.HideUntilContentRendered(this);
     }
 
     private SettingsWindowViewModel ViewModel => (SettingsWindowViewModel)DataContext;

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -35,7 +35,6 @@ public partial class SettingsWindow : Window
     private void Window_SourceInitialized(object sender, EventArgs e)
     {
         Utilities.ThemeManager.ApplyTitleBarTheme(this);
-        Utilities.ThemeManager.ApplyThemedBackgroundErase(this);
     }
 
     private void BrowseBackgroundImagePath(object sender, RoutedEventArgs e)

--- a/DesktopClock/SettingsWindow.xaml.cs
+++ b/DesktopClock/SettingsWindow.xaml.cs
@@ -193,12 +193,11 @@ public partial class SettingsWindow : Window
             return;
         }
 
-        Dispatcher.BeginInvoke(DispatcherPriority.Loaded, new Action(() =>
-        {
-            SettingsScrollViewer.ScrollToVerticalOffset(ViewModel.Settings.SettingsScrollPosition);
-            ViewModel.Settings.SettingsScrollPosition = SettingsScrollViewer.VerticalOffset;
-            _restoringScrollPosition = false;
-        }));
+        // Apply the offset within the same layout pass so the first frame is already at the saved position instead of visibly jumping there after it renders.
+        SettingsScrollViewer.ScrollToVerticalOffset(ViewModel.Settings.SettingsScrollPosition);
+        SettingsScrollViewer.UpdateLayout();
+        ViewModel.Settings.SettingsScrollPosition = SettingsScrollViewer.VerticalOffset;
+        _restoringScrollPosition = false;
     }
 
     private void SettingsScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -64,14 +64,10 @@ public static class ThemeManager
     }
 
     /// <summary>
-    /// Fills the window with the palette's background color whenever Windows asks it to
-    /// erase, so it never flashes white before WPF paints the first frame (or when areas
-    /// are exposed during a resize).
+    /// Fills the window with the palette's background color whenever Windows asks it to erase, so it never flashes white before WPF paints the first frame or when areas are exposed during a resize.
     /// </summary>
     /// <remarks>
-    /// A window's surface starts out white and is on screen before WPF presents anything,
-    /// which reads as a bright flash in dark mode. Call once per window after its handle
-    /// exists, e.g. from <see cref="Window.SourceInitialized"/>.
+    /// A window's surface starts out white and is on screen before WPF presents anything, which reads as a bright flash in dark mode. Call once per window after its handle exists, e.g. from <see cref="Window.SourceInitialized"/>.
     /// </remarks>
     public static void ApplyThemedBackgroundErase(Window window)
     {

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
-using System.Windows.Threading;
 using Microsoft.Win32;
 
 namespace DesktopClock.Utilities;
@@ -18,7 +16,6 @@ public static class ThemeManager
     private const string PaletteFolder = "Themes/";
     private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
     private const int DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19;
-    private const int DWMWA_CLOAK = 13;
 
     private static readonly Uri LightPaletteUri = new(PaletteFolder + "LightPalette.xaml", UriKind.Relative);
     private static readonly Uri DarkPaletteUri = new(PaletteFolder + "DarkPalette.xaml", UriKind.Relative);
@@ -63,76 +60,6 @@ public static class ThemeManager
         catch
         {
             // DWM isn't available; keep the default title bar.
-        }
-    }
-
-    /// <summary>
-    /// Keeps the window invisible until its first frame has rendered, so it can't flash
-    /// as an unpainted white rectangle before WPF draws the themed content.
-    /// </summary>
-    /// <remarks>
-    /// The window's surface starts out white and DWM shows it as soon as the window opens,
-    /// which reads as a bright flash in dark mode. Cloaking hides the window at the DWM level
-    /// (unlike <see cref="Window.Visibility"/>, it doesn't affect layout, activation, or focus)
-    /// until the content is actually on the surface.
-    /// </remarks>
-    public static void HideUntilContentRendered(Window window)
-    {
-        window.SourceInitialized += (_, _) => SetCloaked(window, true);
-
-        // ContentRendered fires when the frame is handed to the render thread, slightly
-        // before it reaches the screen surface, so wait out the render and composition
-        // passes that carry the frame before revealing the window.
-        window.ContentRendered += (_, _) => window.Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(() =>
-        {
-            WaitForRenderThread(window.Dispatcher);
-
-            try
-            {
-                DwmFlush();
-            }
-            catch
-            {
-            }
-
-            SetCloaked(window, false);
-        }));
-    }
-
-    /// <summary>
-    /// Blocks until the render thread has finished presenting the current frame.
-    /// </summary>
-    private static void WaitForRenderThread(Dispatcher dispatcher)
-    {
-        // MediaContext.CompleteRender is what WPF itself uses to sync with the render
-        // thread but it isn't public; if the internals ever change, the cloaked window
-        // just reveals a frame early.
-        try
-        {
-            var mediaContextType = typeof(CompositionTarget).Assembly.GetType("System.Windows.Media.MediaContext");
-            var mediaContext = mediaContextType?.GetMethod("From", BindingFlags.Static | BindingFlags.NonPublic)?.Invoke(null, [dispatcher]);
-            mediaContextType?.GetMethod("CompleteRender", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)?.Invoke(mediaContext, null);
-        }
-        catch
-        {
-        }
-    }
-
-    private static void SetCloaked(Window window, bool cloaked)
-    {
-        var hwnd = new WindowInteropHelper(window).Handle;
-        if (hwnd == IntPtr.Zero)
-            return;
-
-        var value = cloaked ? 1 : 0;
-
-        try
-        {
-            DwmSetWindowAttribute(hwnd, DWMWA_CLOAK, ref value, sizeof(int));
-        }
-        catch
-        {
-            // DWM isn't available; the window just shows normally.
         }
     }
 
@@ -208,7 +135,4 @@ public static class ThemeManager
 
     [DllImport("dwmapi.dll", PreserveSig = true)]
     private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
-
-    [DllImport("dwmapi.dll", PreserveSig = true)]
-    private static extern int DwmFlush();
 }

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -63,6 +63,48 @@ public static class ThemeManager
         }
     }
 
+    /// <summary>
+    /// Fills the window with the palette's background color whenever Windows asks it to
+    /// erase, so it never flashes white before WPF paints the first frame (or when areas
+    /// are exposed during a resize).
+    /// </summary>
+    /// <remarks>
+    /// A window's surface starts out white and is on screen before WPF presents anything,
+    /// which reads as a bright flash in dark mode. Call once per window after its handle
+    /// exists, e.g. from <see cref="Window.SourceInitialized"/>.
+    /// </remarks>
+    public static void ApplyThemedBackgroundErase(Window window)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero || HwndSource.FromHwnd(hwnd) is not { } source)
+            return;
+
+        source.AddHook(EraseBackgroundWithThemeColor);
+    }
+
+    private static IntPtr EraseBackgroundWithThemeColor(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        const int WM_ERASEBKGND = 0x0014;
+
+        if (msg != WM_ERASEBKGND)
+            return IntPtr.Zero;
+
+        // Read the color at message time so theme changes while the window is open apply.
+        if (Application.Current?.TryFindResource("WindowBackgroundBrush") is not SolidColorBrush brush ||
+            !GetClientRect(hwnd, out var clientRect))
+        {
+            return IntPtr.Zero;
+        }
+
+        var colorRef = (uint)(brush.Color.R | (brush.Color.G << 8) | (brush.Color.B << 16));
+        var gdiBrush = CreateSolidBrush(colorRef);
+        FillRect(wParam, ref clientRect, gdiBrush);
+        DeleteObject(gdiBrush);
+
+        handled = true;
+        return new IntPtr(1);
+    }
+
     private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
     {
         // Theme changes arrive as General; accent and high-contrast changes as Color/VisualStyle/Accessibility.
@@ -135,4 +177,22 @@ public static class ThemeManager
 
     [DllImport("dwmapi.dll", PreserveSig = true)]
     private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetClientRect(IntPtr hwnd, out RECT rect);
+
+    [DllImport("user32.dll")]
+    private static extern int FillRect(IntPtr hdc, ref RECT rect, IntPtr brush);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateSolidBrush(uint colorRef);
+
+    [DllImport("gdi32.dll")]
+    private static extern bool DeleteObject(IntPtr obj);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left, Top, Right, Bottom;
+    }
 }

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -63,44 +63,6 @@ public static class ThemeManager
         }
     }
 
-    /// <summary>
-    /// Fills the window with the palette's background color whenever Windows asks it to erase, so it never flashes white before WPF paints the first frame or when areas are exposed during a resize.
-    /// </summary>
-    /// <remarks>
-    /// A window's surface starts out white and is on screen before WPF presents anything, which reads as a bright flash in dark mode. Call once per window after its handle exists, e.g. from <see cref="Window.SourceInitialized"/>.
-    /// </remarks>
-    public static void ApplyThemedBackgroundErase(Window window)
-    {
-        var hwnd = new WindowInteropHelper(window).Handle;
-        if (hwnd == IntPtr.Zero || HwndSource.FromHwnd(hwnd) is not { } source)
-            return;
-
-        source.AddHook(EraseBackgroundWithThemeColor);
-    }
-
-    private static IntPtr EraseBackgroundWithThemeColor(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
-    {
-        const int WM_ERASEBKGND = 0x0014;
-
-        if (msg != WM_ERASEBKGND)
-            return IntPtr.Zero;
-
-        // Read the color at message time so theme changes while the window is open apply.
-        if (Application.Current?.TryFindResource("WindowBackgroundBrush") is not SolidColorBrush brush ||
-            !GetClientRect(hwnd, out var clientRect))
-        {
-            return IntPtr.Zero;
-        }
-
-        var colorRef = (uint)(brush.Color.R | (brush.Color.G << 8) | (brush.Color.B << 16));
-        var gdiBrush = CreateSolidBrush(colorRef);
-        FillRect(wParam, ref clientRect, gdiBrush);
-        DeleteObject(gdiBrush);
-
-        handled = true;
-        return new IntPtr(1);
-    }
-
     private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
     {
         // Theme changes arrive as General; accent and high-contrast changes as Color/VisualStyle/Accessibility.
@@ -173,22 +135,4 @@ public static class ThemeManager
 
     [DllImport("dwmapi.dll", PreserveSig = true)]
     private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
-
-    [DllImport("user32.dll")]
-    private static extern bool GetClientRect(IntPtr hwnd, out RECT rect);
-
-    [DllImport("user32.dll")]
-    private static extern int FillRect(IntPtr hdc, ref RECT rect, IntPtr brush);
-
-    [DllImport("gdi32.dll")]
-    private static extern IntPtr CreateSolidBrush(uint colorRef);
-
-    [DllImport("gdi32.dll")]
-    private static extern bool DeleteObject(IntPtr obj);
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct RECT
-    {
-        public int Left, Top, Right, Bottom;
-    }
 }

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
+using System.Windows.Threading;
 using Microsoft.Win32;
 
 namespace DesktopClock.Utilities;
@@ -16,6 +18,7 @@ public static class ThemeManager
     private const string PaletteFolder = "Themes/";
     private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
     private const int DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19;
+    private const int DWMWA_CLOAK = 13;
 
     private static readonly Uri LightPaletteUri = new(PaletteFolder + "LightPalette.xaml", UriKind.Relative);
     private static readonly Uri DarkPaletteUri = new(PaletteFolder + "DarkPalette.xaml", UriKind.Relative);
@@ -60,6 +63,76 @@ public static class ThemeManager
         catch
         {
             // DWM isn't available; keep the default title bar.
+        }
+    }
+
+    /// <summary>
+    /// Keeps the window invisible until its first frame has rendered, so it can't flash
+    /// as an unpainted white rectangle before WPF draws the themed content.
+    /// </summary>
+    /// <remarks>
+    /// The window's surface starts out white and DWM shows it as soon as the window opens,
+    /// which reads as a bright flash in dark mode. Cloaking hides the window at the DWM level
+    /// (unlike <see cref="Window.Visibility"/>, it doesn't affect layout, activation, or focus)
+    /// until the content is actually on the surface.
+    /// </remarks>
+    public static void HideUntilContentRendered(Window window)
+    {
+        window.SourceInitialized += (_, _) => SetCloaked(window, true);
+
+        // ContentRendered fires when the frame is handed to the render thread, slightly
+        // before it reaches the screen surface, so wait out the render and composition
+        // passes that carry the frame before revealing the window.
+        window.ContentRendered += (_, _) => window.Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(() =>
+        {
+            WaitForRenderThread(window.Dispatcher);
+
+            try
+            {
+                DwmFlush();
+            }
+            catch
+            {
+            }
+
+            SetCloaked(window, false);
+        }));
+    }
+
+    /// <summary>
+    /// Blocks until the render thread has finished presenting the current frame.
+    /// </summary>
+    private static void WaitForRenderThread(Dispatcher dispatcher)
+    {
+        // MediaContext.CompleteRender is what WPF itself uses to sync with the render
+        // thread but it isn't public; if the internals ever change, the cloaked window
+        // just reveals a frame early.
+        try
+        {
+            var mediaContextType = typeof(CompositionTarget).Assembly.GetType("System.Windows.Media.MediaContext");
+            var mediaContext = mediaContextType?.GetMethod("From", BindingFlags.Static | BindingFlags.NonPublic)?.Invoke(null, [dispatcher]);
+            mediaContextType?.GetMethod("CompleteRender", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)?.Invoke(mediaContext, null);
+        }
+        catch
+        {
+        }
+    }
+
+    private static void SetCloaked(Window window, bool cloaked)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero)
+            return;
+
+        var value = cloaked ? 1 : 0;
+
+        try
+        {
+            DwmSetWindowAttribute(hwnd, DWMWA_CLOAK, ref value, sizeof(int));
+        }
+        catch
+        {
+            // DWM isn't available; the window just shows normally.
         }
     }
 
@@ -135,4 +208,7 @@ public static class ThemeManager
 
     [DllImport("dwmapi.dll", PreserveSig = true)]
     private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmFlush();
 }

--- a/DesktopClock/Utilities/ThemeManager.cs
+++ b/DesktopClock/Utilities/ThemeManager.cs
@@ -63,6 +63,44 @@ public static class ThemeManager
         }
     }
 
+    /// <summary>
+    /// Fills the window with the palette's background color whenever Windows asks it to erase, so it never flashes white before WPF paints the first frame or when areas are exposed during a resize.
+    /// </summary>
+    /// <remarks>
+    /// A window's surface starts out white and is on screen before WPF presents anything, which reads as a bright flash in dark mode. Call once per window after its handle exists, e.g. from <see cref="Window.SourceInitialized"/>.
+    /// </remarks>
+    public static void ApplyThemedBackgroundErase(Window window)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero || HwndSource.FromHwnd(hwnd) is not { } source)
+            return;
+
+        source.AddHook(EraseBackgroundWithThemeColor);
+    }
+
+    private static IntPtr EraseBackgroundWithThemeColor(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        const int WM_ERASEBKGND = 0x0014;
+
+        if (msg != WM_ERASEBKGND)
+            return IntPtr.Zero;
+
+        // Read the color at message time so theme changes while the window is open apply.
+        if (Application.Current?.TryFindResource("WindowBackgroundBrush") is not SolidColorBrush brush ||
+            !GetClientRect(hwnd, out var clientRect))
+        {
+            return IntPtr.Zero;
+        }
+
+        var colorRef = (uint)(brush.Color.R | (brush.Color.G << 8) | (brush.Color.B << 16));
+        var gdiBrush = CreateSolidBrush(colorRef);
+        FillRect(wParam, ref clientRect, gdiBrush);
+        DeleteObject(gdiBrush);
+
+        handled = true;
+        return new IntPtr(1);
+    }
+
     private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
     {
         // Theme changes arrive as General; accent and high-contrast changes as Color/VisualStyle/Accessibility.
@@ -135,4 +173,22 @@ public static class ThemeManager
 
     [DllImport("dwmapi.dll", PreserveSig = true)]
     private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetClientRect(IntPtr hwnd, out RECT rect);
+
+    [DllImport("user32.dll")]
+    private static extern int FillRect(IntPtr hdc, ref RECT rect, IntPtr brush);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateSolidBrush(uint colorRef);
+
+    [DllImport("gdi32.dll")]
+    private static extern bool DeleteObject(IntPtr obj);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left, Top, Right, Bottom;
+    }
 }


### PR DESCRIPTION
## Problem

Since the recent settings-page additions (#140, #142) and the dark retheme (#138), opening the settings window felt slow, flashed a white rectangle before the dark content appeared, and visibly jumped to the saved scroll position after rendering.

Profiling with instrumented harnesses (clock running, pixel-sampling the screen during open) attributed it to three independent causes:

1. **~85 ms of every open** was `TimeZoneInfo.GetSystemTimeZones()` + system font enumeration running synchronously in the viewmodel constructor.
2. **The white flash was always there** — a window's surface is white until WPF presents its first frame, and DWM fades the window in before that. Pre-#138 the page was light so it was invisible; dark mode exposed it.
3. **The scroll restore ran a dispatcher pass after the first frame**, so the page rendered at the top and then jumped to the saved position.

Ruled out along the way: no individual control is heavy (30 chip buttons ≈ 13 ms; all checkboxes/textboxes/combos/sliders combined ≈ 50 ms cold across the 845-element tree), card drop shadows ≈ 0 ms, and deferring all below-fold sections saves only ~50 ms because ~125 ms is fixed window-materialization + XAML parse cost.

## Fix (one commit each)

- **Background enumeration** (6c6fcbf): fonts and time zones are fetched once on a background task started while the app is idle after startup. If settings opens first, the binding just waits for the remainder — never slower than before.
- **Themed background erase** (40cab14, restored in 5b89ee4): the settings window handles `WM_ERASEBKGND` and fills the client area with the palette's `WindowBackgroundBrush` color via GDI, which lands before WPF's first frame. The color is read at message time, so dark/light/high-contrast and live theme switches all behave, and it also covers regions exposed during resizes.
- **First-frame scroll restore** (f12109f): the saved scroll offset is applied within the initial layout pass, verified programmatically — the first rendered frame is already at the saved position.

## Measured (screen pixel sampling at the window center during open, Debug)

| | before | after |
|---|---|---|
| fade-in blends toward | `#FFFFFF`, holds solid white ~55 ms | `#202020` (theme background) |
| white frames observed | yes | none |
| scroll position | jumps after first frame | correct in first frame |
| click → fully rendered | ~335 ms | ~250 ms (vs ~350 ms before the redesign) |

The open now reads as: themed window fades in, content appears once in its final position, nothing shifts. No window lifecycle changes or DWM tricks.