### PR TITLE
Fix automatic countdown being skewed by the UTC offset

### DIFF
--- a/DesktopClock.Tests/TimeStringFormatterTests.cs
+++ b/DesktopClock.Tests/TimeStringFormatterTests.cs
@@ -106,7 +106,48 @@ public class TimeStringFormatterTests
                 " ",
                 CultureInfo.CurrentCulture);
 
-            Assert.Equal(countdownTo.Humanize(utcDate: false, dateToCompareAgainst: nowDateTime), result);
+            var localNow = DateTime.SpecifyKind(nowDateTime, DateTimeKind.Local);
+            Assert.Equal(countdownTo.Humanize(utcDate: false, dateToCompareAgainst: localNow), result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+
+    [Theory]
+    [InlineData(0, "now")]
+    [InlineData(3, "3 hours from now")]
+    [InlineData(-3, "3 hours ago")]
+    [InlineData(72, "3 days from now")]
+    [InlineData(-72, "3 days ago")]
+    public void Format_HumanizedCountdownIsRelativeToNow(int hoursFromNow, string expected)
+    {
+        // The wall-clock values have Kind Unspecified, which Humanizer used to shift by the
+        // machine's UTC offset, e.g. a target of "now" read as "6 hours from now" on UTC-6.
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            var enUs = new CultureInfo("en-US");
+            CultureInfo.CurrentCulture = enUs;
+            CultureInfo.CurrentUICulture = enUs;
+
+            var now = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+            var countdownTo = now.DateTime.AddHours(hoursFromNow);
+
+            var result = TimeStringFormatter.Format(
+                now,
+                now.DateTime,
+                TimeZoneInfo.Utc,
+                countdownTo,
+                "HH:mm",
+                "",
+                CultureInfo.CurrentCulture);
+
+            Assert.Equal(expected, result);
         }
         finally
         {

--- a/DesktopClock/Utilities/TimeStringFormatter.cs
+++ b/DesktopClock/Utilities/TimeStringFormatter.cs
@@ -24,7 +24,11 @@ public static class TimeStringFormatter
         }
         else if (string.IsNullOrWhiteSpace(countdownFormat))
         {
-            result = countdownTo.Humanize(utcDate: false, dateToCompareAgainst: nowDateTime);
+            // Both values are local wall-clock times, but their Kind is usually Unspecified, which Humanizer
+            // shifts by the UTC offset when it converts the comparison date to local time. Pinning the Kind
+            // makes that conversion a no-op so the countdown reads correctly in every time zone.
+            var localNow = DateTime.SpecifyKind(nowDateTime, DateTimeKind.Local);
+            result = countdownTo.Humanize(utcDate: false, dateToCompareAgainst: localNow);
         }
         else
         {

--- a/DesktopClock/Utilities/TimeStringFormatter.cs
+++ b/DesktopClock/Utilities/TimeStringFormatter.cs
@@ -24,9 +24,7 @@ public static class TimeStringFormatter
         }
         else if (string.IsNullOrWhiteSpace(countdownFormat))
         {
-            // Both values are local wall-clock times, but their Kind is usually Unspecified, which Humanizer
-            // shifts by the UTC offset when it converts the comparison date to local time. Pinning the Kind
-            // makes that conversion a no-op so the countdown reads correctly in every time zone.
+            // Humanizer shifts Unspecified times by the UTC offset when localizing, so pin the Kind to make that conversion a no-op.
             var localNow = DateTime.SpecifyKind(nowDateTime, DateTimeKind.Local);
             result = countdownTo.Humanize(utcDate: false, dateToCompareAgainst: localNow);
         }


### PR DESCRIPTION
The default countdown display (empty format, the "Automatic" preset) was wrong by the machine's UTC offset for every non-UTC user. On UTC-6, a target of exactly now showed "6 hours from now".

**Cause:** `nowDateTime` is a local wall-clock value with `Kind=Unspecified`. Humanizer converts the comparison date into the frame implied by `utcDate` (`ToLocalTime()` for `false`), and that conversion shifts Unspecified values by the UTC offset.

**Fix:** pin the comparison date's Kind to `Local` so the conversion is a no-op. Verified empirically against the built exe on a UTC-6 machine:

| Target | Before | After |
|---|---|---|
| exactly now | 6 hours from now | now |
| +3 hours | 9 hours from now | 3 hours from now |
| -3 hours | 3 hours from now | 3 hours ago |
| -25 hours | 19 hours ago | yesterday |

- Tokenized countdown formats were never affected (they subtract the dates directly)
- Not a v5.5.0 regression; the call is identical at v5.4.0
- New tests assert the humanized wording relative to now; note CI runners are UTC where the old code also passed, so the proof is the local run above