### PR TITLE
Zero-pad the week token to match ISO 8601

### DIFF
--- a/DesktopClock.Tests/TimeStringFormatterTests.cs
+++ b/DesktopClock.Tests/TimeStringFormatterTests.cs
@@ -149,7 +149,7 @@ public class TimeStringFormatterTests
             null,
             CultureInfo.InvariantCulture);
 
-        Assert.Equal("2025-W1", result);
+        Assert.Equal("2025-W01", result);
     }
 
     [Fact]

--- a/DesktopClock.Tests/TokenizerTests.cs
+++ b/DesktopClock.Tests/TokenizerTests.cs
@@ -112,10 +112,11 @@ public class TokenizerTests
     }
 
     [Theory]
-    [InlineData("2024-01-01", "Week 1")]
+    [InlineData("2024-01-01", "Week 01")]
     [InlineData("2024-12-29", "Week 52")]
-    [InlineData("2024-12-30", "Week 1")]
+    [InlineData("2024-12-30", "Week 01")]
     [InlineData("2021-01-01", "Week 53")]
+    [InlineData("2026-02-02", "Week 06")]
     public void FormatWithTokenizer_WeekToken_ShouldUseIsoWeek(string dateString, string expected)
     {
         // Arrange
@@ -130,7 +131,7 @@ public class TokenizerTests
     }
 
     [Theory]
-    [InlineData("2024-12-30", "2025-W1")]
+    [InlineData("2024-12-30", "2025-W01")]
     [InlineData("2021-01-01", "2020-W53")]
     [InlineData("2026-05-06", "2026-W19")]
     public void FormatWithTokenizer_WeekYearToken_ShouldUseIsoWeekYear(string dateString, string expected)
@@ -157,7 +158,7 @@ public class TokenizerTests
         var result = Tokenizer.FormatWithTokenizerOrFallBack(dateTimeOffset, format, CultureInfo.InvariantCulture);
 
         // Assert
-        Assert.Equal("Mon, Dec 30 (W1)", result);
+        Assert.Equal("Mon, Dec 30 (W01)", result);
     }
 
     [Fact]

--- a/DesktopClock/Utilities/Tokenizer.cs
+++ b/DesktopClock/Utilities/Tokenizer.cs
@@ -72,8 +72,10 @@ public static class Tokenizer
         else
             return false;
 
-        var value = token == "week" ? dateTime.GetIsoWeekOfYear() : dateTime.GetIsoWeekYear();
-        result = value.ToString(formatProvider);
+        // ISO 8601 writes the week as two digits, like 2026-W05.
+        result = token == "week"
+            ? dateTime.GetIsoWeekOfYear().ToString("D2", formatProvider)
+            : dateTime.GetIsoWeekYear().ToString(formatProvider);
         return true;
     }
 


### PR DESCRIPTION
The "ISO week" preset `{weekYear}-W{week}` produced `2026-W5` for weeks 1-9, but ISO 8601 week-date notation is two digits: `2026-W05`.

- `{week}` now formats with `D2`, so `W5` becomes `W05`
- `{weekYear}` is unchanged
- The FormatEditor preset chip and preview pick up the new output automatically

Judgment call: this also changes standalone uses like `Week {week}`, which now render `Week 06` mid-single-digit weeks. If you prefer the unpadded look for prose formats, the alternative is leaving `{week}` alone and documenting the preset as approximate; happy to rework.