### PR TITLE
Show a negative sign when a tokenized countdown has passed

### DIFF
--- a/DesktopClock.Tests/TimeStringFormatterTests.cs
+++ b/DesktopClock.Tests/TimeStringFormatterTests.cs
@@ -81,6 +81,29 @@ public class TimeStringFormatterTests
         Assert.Equal((countdownTo - nowDateTime).ToString("c", formatProvider), result);
     }
 
+    [Theory]
+    [InlineData("{hh\\:mm\\:ss}", "-01:30:00")] // Tokenized custom format
+    [InlineData("{%h}h {%m}m", "-1h 30m")] // Tokenized preset style
+    [InlineData("c", "-01:30:00")] // Standard format keeps a single sign
+    [InlineData("{bad}", "Bad format")] // Errors are not prefixed
+    public void Format_PastCountdownShowsNegativeSign(string countdownFormat, string expected)
+    {
+        var now = new DateTimeOffset(2024, 1, 1, 10, 0, 0, TimeSpan.Zero);
+        var nowDateTime = now.DateTime;
+        var countdownTo = nowDateTime.AddMinutes(-90);
+
+        var result = TimeStringFormatter.Format(
+            now,
+            nowDateTime,
+            TimeZoneInfo.Utc,
+            countdownTo,
+            "HH:mm",
+            countdownFormat,
+            CultureInfo.InvariantCulture);
+
+        Assert.Equal(expected, result);
+    }
+
     [Fact]
     public void Format_UsesHumanizerWhenCountdownFormatMissing()
     {

--- a/DesktopClock/Utilities/TimeStringFormatter.cs
+++ b/DesktopClock/Utilities/TimeStringFormatter.cs
@@ -30,8 +30,7 @@ public static class TimeStringFormatter
         {
             var countdown = countdownTo - nowDateTime;
 
-            // Custom TimeSpan formats drop the sign, so format the magnitude and add the sign back
-            // to keep an elapsed target from reading like time remaining.
+            // Custom TimeSpan formats drop the sign, so format the magnitude and add it back to mark an elapsed target.
             var isElapsed = countdown < TimeSpan.Zero;
             result = Tokenizer.FormatWithTokenizerOrFallBack(isElapsed ? countdown.Negate() : countdown, countdownFormat, formatProvider);
 

--- a/DesktopClock/Utilities/TimeStringFormatter.cs
+++ b/DesktopClock/Utilities/TimeStringFormatter.cs
@@ -29,7 +29,14 @@ public static class TimeStringFormatter
         else
         {
             var countdown = countdownTo - nowDateTime;
-            result = Tokenizer.FormatWithTokenizerOrFallBack(countdown, countdownFormat, formatProvider);
+
+            // Custom TimeSpan formats drop the sign, so format the magnitude and add the sign back
+            // to keep an elapsed target from reading like time remaining.
+            var isElapsed = countdown < TimeSpan.Zero;
+            result = Tokenizer.FormatWithTokenizerOrFallBack(isElapsed ? countdown.Negate() : countdown, countdownFormat, formatProvider);
+
+            if (isElapsed && result != Tokenizer.FormatErrorMessage)
+                result = "-" + result;
         }
 
         return result;


### PR DESCRIPTION
Custom TimeSpan format strings drop the sign, so a countdown 3 days past due rendered exactly like 3 days remaining with formats such as `{%d}d {%h}h` or the new Digital preset.

**Fix:** format the magnitude and prefix `-` when the target has passed.

| Format, target 90 min ago | Before | After |
|---|---|---|
| `{hh}:{mm}:{ss}` | 01:30:00 | -01:30:00 |
| `{%h}h {%m}m` | 1h 30m | -1h 30m |
| `c` (standard, already signed) | -01:30:00 | -01:30:00 (no double sign) |

- The Automatic (Humanizer) path already says "ago" and is untouched
- "Bad format" errors are not prefixed
- Pre-existing behavior, surfaced by the new one-click presets
- Note: this touches the same method as #146, so whichever merges second needs a trivial rebase