### PR TITLE
Fix hover, pressed, and highlight states in high contrast

### DIFF
--- a/DesktopClock/Themes/DarkPalette.xaml
+++ b/DesktopClock/Themes/DarkPalette.xaml
@@ -10,6 +10,8 @@
     <SolidColorBrush x:Key="SeparatorBrush" Color="#3F3F3F" />
     <SolidColorBrush x:Key="TextPrimaryBrush" Color="#FFFFFF" />
     <SolidColorBrush x:Key="TextSecondaryBrush" Color="#A6A6A6" />
+    <!-- Foreground on a hover/highlight fill; matches primary text since the fill is only a subtle tint here. -->
+    <SolidColorBrush x:Key="OnHoverTextBrush" Color="#FFFFFF" />
     <SolidColorBrush x:Key="HoverBrush" Color="#383838" />
     <SolidColorBrush x:Key="PressedBrush" Color="#303030" />
     <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#2E2E2E" />

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -48,9 +48,11 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="border" Property="Background" Value="{DynamicResource PressedBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsKeyboardFocused" Value="True">
                             <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
@@ -114,12 +116,15 @@
                         <Trigger Property="local:NavButton.IsActive" Value="True">
                             <Setter TargetName="ActivePill" Property="Visibility" Value="Visible" />
                             <Setter TargetName="border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="border" Property="Background" Value="{DynamicResource PressedBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsKeyboardFocused" Value="True">
                             <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
@@ -246,9 +251,11 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="True">
                             <Setter TargetName="Border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="Border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
                             <Setter TargetName="SelectionPill" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
@@ -300,7 +307,8 @@
                                           ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" />
 
                         <!-- Chevron -->
-                        <Path Data="M 0,0 L 4.5,4.5 L 9,0"
+                        <Path x:Name="Chevron"
+                              Data="M 0,0 L 4.5,4.5 L 9,0"
                               Stroke="{DynamicResource TextSecondaryBrush}"
                               StrokeThickness="1.5"
                               StrokeStartLineCap="Round"
@@ -346,9 +354,13 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
+                            <Setter TargetName="Chevron" Property="Stroke" Value="{DynamicResource OnHoverTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsDropDownOpen" Value="True">
                             <Setter TargetName="Border" Property="Background" Value="{DynamicResource PressedBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
+                            <Setter TargetName="Chevron" Property="Stroke" Value="{DynamicResource OnHoverTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsKeyboardFocusWithin" Value="True">
                             <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
@@ -767,6 +779,9 @@
                         </Trigger>
                         <Trigger Property="IsHighlighted" Value="True">
                             <Setter TargetName="Border" Property="Background" Value="{DynamicResource HoverBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
+                            <Setter TargetName="CheckMark" Property="Stroke" Value="{DynamicResource OnHoverTextBrush}" />
+                            <Setter TargetName="GestureText" Property="Foreground" Value="{DynamicResource OnHoverTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />

--- a/DesktopClock/Themes/HighContrastPalette.xaml
+++ b/DesktopClock/Themes/HighContrastPalette.xaml
@@ -10,8 +10,10 @@
     <SolidColorBrush x:Key="SeparatorBrush" Color="{DynamicResource {x:Static SystemColors.ActiveBorderColorKey}}" />
     <SolidColorBrush x:Key="TextPrimaryBrush" Color="{DynamicResource {x:Static SystemColors.WindowTextColorKey}}" />
     <SolidColorBrush x:Key="TextSecondaryBrush" Color="{DynamicResource {x:Static SystemColors.GrayTextColorKey}}" />
-    <SolidColorBrush x:Key="HoverBrush" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
-    <SolidColorBrush x:Key="PressedBrush" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
+    <SolidColorBrush x:Key="OnHoverTextBrush" Color="{DynamicResource {x:Static SystemColors.HighlightTextColorKey}}" />
+    <!-- Highlight, not Control: in every built-in high-contrast theme Control equals the window surface, so a Control-colored hover would be invisible. -->
+    <SolidColorBrush x:Key="HoverBrush" Color="{DynamicResource {x:Static SystemColors.HighlightColorKey}}" />
+    <SolidColorBrush x:Key="PressedBrush" Color="{DynamicResource {x:Static SystemColors.HighlightColorKey}}" />
     <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
     <SolidColorBrush x:Key="ButtonBorderBrush" Color="{DynamicResource {x:Static SystemColors.ControlTextColorKey}}" />
     <SolidColorBrush x:Key="ControlFillBrush" Color="{DynamicResource {x:Static SystemColors.WindowColorKey}}" />

--- a/DesktopClock/Themes/LightPalette.xaml
+++ b/DesktopClock/Themes/LightPalette.xaml
@@ -10,6 +10,8 @@
     <SolidColorBrush x:Key="SeparatorBrush" Color="#E5E5E5" />
     <SolidColorBrush x:Key="TextPrimaryBrush" Color="#1A1A1A" />
     <SolidColorBrush x:Key="TextSecondaryBrush" Color="#5D5D5D" />
+    <!-- Foreground on a hover/highlight fill; matches primary text since the fill is only a subtle tint here. -->
+    <SolidColorBrush x:Key="OnHoverTextBrush" Color="#1A1A1A" />
     <SolidColorBrush x:Key="HoverBrush" Color="#EAEAEA" />
     <SolidColorBrush x:Key="PressedBrush" Color="#E0E0E0" />
     <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#FBFBFB" />


### PR DESCRIPTION

The high-contrast palette (new in v5.5.0) maps `HoverBrush` and `PressedBrush` to the system **Control** color. In every built-in Windows high-contrast theme, the Control (button-face) color is identical to the **Window** surface color, so those brushes paint a highlight that is the same color as the background behind it — i.e. invisible.

The result for a high-contrast user:

- Arrow-keying or hovering through the clock's right-click menu and the tray menu — the app's primary interaction surface, since the clock window is chromeless — gives **no indication of which item is selected**.
- ComboBox dropdown navigation (Display / Typography / Appearance), button hover/press, and the checkbox hover all produce **zero visual change**.

This is exactly the mode where these cues matter most, and it's a regression from v5.4.0, whose stock WPF menus used the system Highlight color for the selected item.

Verification
- **High contrast — before:** highlighted menu item, selected dropdown item, and hovered button all have no visible fill (screenshot `hc-highlight-before.png`).
- **High contrast — after:** each shows the system Highlight fill with legible HighlightText (`hc-highlight-after.png`).
- **Light / dark:** unchanged subtle-gray highlight with primary-colored text (`hc-light-unchanged.png`, `hc-dark-unchanged.png`).
- Resolved values confirmed: HC `HoverBrush` → `SystemColors.Highlight` (≠ window surface), `OnHoverTextBrush` → `SystemColors.HighlightText`; light/dark `OnHoverTextBrush` equals primary text.

Before/after

<img width="303" height="469" alt="image" src="https://github.com/user-attachments/assets/997f62d1-260f-46e8-8e4c-d05d9bab21c6" />

<img width="301" height="467" alt="image" src="https://github.com/user-attachments/assets/e8729f4c-048f-4862-b74a-99499f324a7e" />
