### PR TITLE
Fall back to the solid color when the background image can't load

### DIFF
--- a/DesktopClock/MainWindow.xaml
+++ b/DesktopClock/MainWindow.xaml
@@ -113,42 +113,16 @@
     <Viewbox Height="{Binding Height, Source={x:Static p:Settings.Default}, Mode=OneWay}">
         <Border CornerRadius="{Binding BackgroundCornerRadius, Source={x:Static p:Settings.Default}, Mode=OneWay}"
                 Padding="1,0,1,0">
-            <Border.Style>
-                <Style TargetType="Border">
-                    <Setter Property="Background" Value="Transparent" />
-
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding BackgroundEnabled, Source={x:Static p:Settings.Default}, Mode=OneWay}"
-                                     Value="True">
-                            <DataTrigger.Setters>
-                                <Setter Property="Background">
-                                    <Setter.Value>
-                                        <ImageBrush Opacity="{Binding BackgroundOpacity, Source={x:Static p:Settings.Default}, Mode=OneWay}"
-                                                    ImageSource="{Binding BackgroundImagePath, Source={x:Static p:Settings.Default}, Mode=OneWay}"
-                                                    Stretch="{Binding BackgroundImageStretch, Source={x:Static p:Settings.Default}, Mode=OneWay}" />
-                                    </Setter.Value>
-                                </Setter>
-                            </DataTrigger.Setters>
-                        </DataTrigger>
-
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding BackgroundEnabled, Source={x:Static p:Settings.Default}, Mode=OneWay}" Value="True" />
-                                <Condition Binding="{Binding BackgroundImagePath, Source={x:Static p:Settings.Default}, Mode=OneWay}" Value="" />
-                            </MultiDataTrigger.Conditions>
-
-                            <MultiDataTrigger.Setters>
-                                <Setter Property="Background">
-                                    <Setter.Value>
-                                        <SolidColorBrush Opacity="{Binding BackgroundOpacity, Source={x:Static p:Settings.Default}, Mode=OneWay}"
-                                                         Color="{Binding OuterColor, Source={x:Static p:Settings.Default}, Mode=OneWay}" />
-                                    </Setter.Value>
-                                </Setter>
-                            </MultiDataTrigger.Setters>
-                        </MultiDataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Border.Style>
+            <Border.Background>
+                <!-- Falls back to the solid outer color when the background image is missing or unreadable, so the clock is never left with an invisible background. -->
+                <MultiBinding Converter="{local:BackgroundBrushConverter}">
+                    <Binding Path="BackgroundEnabled" Source="{x:Static p:Settings.Default}" Mode="OneWay" />
+                    <Binding Path="BackgroundImagePath" Source="{x:Static p:Settings.Default}" Mode="OneWay" />
+                    <Binding Path="OuterColor" Source="{x:Static p:Settings.Default}" Mode="OneWay" />
+                    <Binding Path="BackgroundOpacity" Source="{x:Static p:Settings.Default}" Mode="OneWay" />
+                    <Binding Path="BackgroundImageStretch" Source="{x:Static p:Settings.Default}" Mode="OneWay" />
+                </MultiBinding>
+            </Border.Background>
 
             <local:OutlinedTextBlock Text="{Binding CurrentTimeOrCountdownString}"
                                      StrokeThickness="{Binding OutlineThickness, Source={x:Static p:Settings.Default}, Mode=OneWay}"

--- a/DesktopClock/Utilities/BackgroundBrushConverter.cs
+++ b/DesktopClock/Utilities/BackgroundBrushConverter.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Markup;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace DesktopClock;
+
+/// <summary>
+/// Builds the clock's background brush from the current settings, falling back to the solid outer color when a chosen background image is missing or can't be read.
+/// </summary>
+/// <remarks>
+/// Bound values, in order: BackgroundEnabled, BackgroundImagePath, OuterColor, BackgroundOpacity, BackgroundImageStretch.
+/// </remarks>
+public class BackgroundBrushConverter : MarkupExtension, IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        var enabled = values.Length > 0 && values[0] is bool b && b;
+
+        // Background off means outlined text on a transparent window.
+        if (!enabled)
+            return Brushes.Transparent;
+
+        var path = values.Length > 1 ? values[1] as string : null;
+        var outerColor = values.Length > 2 && values[2] is Color color ? color : Colors.Transparent;
+        var opacity = values.Length > 3 && values[3] is double o ? o : 1d;
+        var stretch = values.Length > 4 && values[4] is Stretch s ? s : Stretch.Fill;
+
+        // Use the image when it loads; otherwise fall back to the solid color so the clock never ends up with an invisible background.
+        var image = TryLoadImage(path);
+        if (image != null)
+            return new ImageBrush(image) { Opacity = opacity, Stretch = stretch };
+
+        return new SolidColorBrush(outerColor) { Opacity = opacity };
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+
+    public override object ProvideValue(IServiceProvider serviceProvider) => this;
+
+    private static ImageSource TryLoadImage(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        try
+        {
+            var bitmap = new BitmapImage();
+            bitmap.BeginInit();
+            bitmap.CacheOption = BitmapCacheOption.OnLoad; // Decode now so a missing or invalid file fails here, and don't hold the file locked.
+            bitmap.UriSource = new Uri(path, UriKind.Absolute);
+            bitmap.EndInit();
+            bitmap.Freeze();
+            return bitmap;
+        }
+        catch
+        {
+            // Missing file, non-image content, unavailable share, or a malformed path all fall back to the solid color.
+            return null;
+        }
+    }
+}


### PR DESCRIPTION

When a background image is set and then becomes unreadable — the file is deleted, moved, replaced with a non-image file (the picker offers an "All files" filter), or lives on an unavailable network share — the `ImageBrush` fails to load, WPF swallows the error, and the brush paints nothing. The clock is left with a **fully transparent background and no outline**, so e.g. white text sits directly on the desktop with no backing and can be unreadable.

The existing solid-color fallback only triggered when the path was *empty*, so a set-but-broken path fell through to a blank background.

Fixed by building the background brush through a small `IMultiValueConverter` (`BackgroundBrushConverter`) instead of the style triggers:

- Background off → transparent (outlined-text mode), unchanged.
- Background on, image loads → `ImageBrush`, exactly as before.
- Background on, image missing / non-image / unreadable / empty path → solid `OuterColor`.

The image is loaded with `BitmapCacheOption.OnLoad` inside a `try`/`catch`, so a bad file fails predictably (and the file isn't held open). A valid image renders identically to before, including transparent gaps with Uniform/None stretch.

| Case | Before | After |
| --- | --- | --- |
| Valid image | image | image (unchanged) |
| Missing file | **no background** | solid color |
| Non-image file | **no background** | solid color |
| Empty path | solid color | solid color (unchanged) |
| Background disabled | transparent + outline | transparent + outline (unchanged) |
