### PR TITLE
Accept countdown target dates in the user's locale

### DIFF
--- a/DesktopClock/CountdownTargetEditor.xaml.cs
+++ b/DesktopClock/CountdownTargetEditor.xaml.cs
@@ -1,7 +1,9 @@
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Markup;
 using DesktopClock.Properties;
 using Humanizer;
 
@@ -26,6 +28,9 @@ public partial class CountdownTargetEditor : UserControl
     public CountdownTargetEditor()
     {
         InitializeComponent();
+
+        // WPF defaults every element's Language to en-US, so the target text box would parse and show dates only in US format. Follow the OS locale instead, matching the preset captions and preview below it.
+        Language = XmlLanguage.GetLanguage(CultureInfo.CurrentCulture.IetfLanguageTag);
 
         Loaded += CountdownTargetEditor_Loaded;
         Unloaded += (_, _) => Settings.Default.PropertyChanged -= Settings_PropertyChanged;

--- a/DesktopClock/CountdownTargetEditor.xaml.cs
+++ b/DesktopClock/CountdownTargetEditor.xaml.cs
@@ -27,10 +27,10 @@ public partial class CountdownTargetEditor : UserControl
 
     public CountdownTargetEditor()
     {
-        InitializeComponent();
-
-        // WPF defaults every element's Language to en-US, so the target text box would parse and show dates only in US format. Follow the OS locale instead, matching the preset captions and preview below it.
+        // WPF defaults every element's Language to en-US, so the target text box would parse and show dates only in US format. Follow the OS locale instead, matching the preset captions and preview below it. Set before InitializeComponent so the culture is already in place when the bindings are created.
         Language = XmlLanguage.GetLanguage(CultureInfo.CurrentCulture.IetfLanguageTag);
+
+        InitializeComponent();
 
         Loaded += CountdownTargetEditor_Loaded;
         Unloaded += (_, _) => Settings.Default.PropertyChanged -= Settings_PropertyChanged;


### PR DESCRIPTION
The countdown **Custom target** text box binds a `DateTime` with no `ConverterCulture`, so WPF uses the element's `Language` — which defaults to **en-US** for every WPF element regardless of the OS locale. A German or French user who types a date in their own format (e.g. `25.12.2026 18:00`) gets it **silently rejected** on focus loss: no error, the value just doesn't change.

It's made worse by the surrounding UI: the preset captions ("Sat, Jul 12, 9:00 AM") and the plain-words preview below the box both render in the OS locale, so the user is shown dates in exactly the format the box refuses to parse.

Fixed by setting the editor's `Language` from `CultureInfo.CurrentCulture` in the constructor. Because `Language` inherits down the visual tree, the target text box now parses **and** displays dates in the user's locale, consistent with the captions and preview. On an en-US machine nothing changes.
