### PR TITLE
Match Windows 11 type ramp in settings and menus

### DIFF
--- a/DesktopClock/CountdownTargetEditor.xaml
+++ b/DesktopClock/CountdownTargetEditor.xaml
@@ -32,7 +32,7 @@
                 Padding="10,7">
             <StackPanel>
                 <TextBlock Text="Preview"
-                           FontSize="11"
+                           FontSize="12"
                            Foreground="{DynamicResource TextSecondaryBrush}"
                            Margin="0,0,0,2" />
                 <TextBlock x:Name="PreviewText"

--- a/DesktopClock/CountdownTargetEditor.xaml.cs
+++ b/DesktopClock/CountdownTargetEditor.xaml.cs
@@ -70,7 +70,7 @@ public partial class CountdownTargetEditor : UserControl
             var example = new TextBlock
             {
                 Text = getTarget().ToString("ddd, MMM d, h:mm tt"),
-                FontSize = 11.5,
+                FontSize = 12,
                 TextTrimming = TextTrimming.CharacterEllipsis,
             };
             example.SetResourceReference(ForegroundProperty, "TextSecondaryBrush");

--- a/DesktopClock/FormatEditor.xaml
+++ b/DesktopClock/FormatEditor.xaml
@@ -33,7 +33,7 @@
                 Padding="10,7">
             <StackPanel>
                 <TextBlock Text="Preview"
-                           FontSize="11"
+                           FontSize="12"
                            Foreground="{DynamicResource TextSecondaryBrush}"
                            Margin="0,0,0,2" />
                 <TextBlock x:Name="PreviewText"

--- a/DesktopClock/FormatEditor.xaml.cs
+++ b/DesktopClock/FormatEditor.xaml.cs
@@ -133,7 +133,7 @@ public partial class FormatEditor : UserControl
             var example = new TextBlock
             {
                 Text = FormatPreview(format),
-                FontSize = 11.5,
+                FontSize = 12,
                 TextTrimming = TextTrimming.CharacterEllipsis,
             };
             example.SetResourceReference(ForegroundProperty, "TextSecondaryBrush");

--- a/DesktopClock/SettingsWindow.xaml
+++ b/DesktopClock/SettingsWindow.xaml
@@ -15,7 +15,7 @@
         ResizeMode="CanResize"
         WindowStartupLocation="CenterScreen"
         FontFamily="Segoe UI Variable Text, Segoe UI"
-        FontSize="13"
+        FontSize="14"
         UseLayoutRounding="True"
         Background="{DynamicResource WindowBackgroundBrush}"
         Foreground="{DynamicResource TextPrimaryBrush}"

--- a/DesktopClock/ThemePresetPicker.xaml.cs
+++ b/DesktopClock/ThemePresetPicker.xaml.cs
@@ -29,7 +29,7 @@ public partial class ThemePresetPicker : UserControl
         var name = new TextBlock
         {
             Text = theme.Name,
-            FontSize = 11.5,
+            FontSize = 12,
             HorizontalAlignment = HorizontalAlignment.Center,
             Margin = new Thickness(0, 4, 0, 0),
         };

--- a/DesktopClock/Themes/FluentTheme.xaml
+++ b/DesktopClock/Themes/FluentTheme.xaml
@@ -82,7 +82,7 @@
         <Setter Property="Margin" Value="0,0,0,2" />
         <Setter Property="Padding" Value="11,7,23,7" />
         <Setter Property="MinHeight" Value="34" />
-        <Setter Property="FontSize" Value="13" />
+        <Setter Property="FontSize" Value="14" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
@@ -154,7 +154,7 @@
 
     <Style x:Key="SidebarToolDescription"
            TargetType="TextBlock">
-        <Setter Property="FontSize" Value="11" />
+        <Setter Property="FontSize" Value="12" />
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="TextWrapping" Value="Wrap" />
         <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
@@ -632,7 +632,8 @@
 
     <Style x:Key="DescriptionTextBlock"
            TargetType="TextBlock">
-        <Setter Property="FontSize" Value="11.5" />
+        <!-- Win11 caption size, one step under the 14px body. -->
+        <Setter Property="FontSize" Value="12" />
         <Setter Property="TextWrapping" Value="Wrap" />
         <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
     </Style>
@@ -698,7 +699,7 @@
     <Style x:Key="MenuIconGlyph"
            TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe Fluent Icons, Segoe MDL2 Assets" />
-        <Setter Property="FontSize" Value="13" />
+        <Setter Property="FontSize" Value="14" />
         <Setter Property="HorizontalAlignment" Value="Center" />
         <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
@@ -706,7 +707,8 @@
     <Style TargetType="{x:Type MenuItem}">
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
-        <Setter Property="FontSize" Value="12" />
+        <!-- Win11 flyout menus use body-size text. -->
+        <Setter Property="FontSize" Value="14" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type MenuItem}">


### PR DESCRIPTION
Text in the settings window and context menus reads smaller than before the Fluent redesign, especially on scaled screens, and sits one step under the Windows 11 type ramp the design imitates. Measured against a stock machine:

| Surface | v5.4.0 (system defaults) | Fluent redesign | Win11 native (WinUI) |
| --- | --- | --- | --- |
| Menus | `SystemFonts.MenuFontSize` (12-13px, tracks OS text size) | **12px** hardcoded | **14px** |
| Body text | `SystemFonts.MessageFontSize` (12-13px) | 13px | **14px** |
| Captions / descriptions | 11px | 11-11.5px | **12px** floor |

So menus genuinely shrank vs v5.4.0, and everything is 1px under the WinUI ramp, which is exactly the "slightly too small, out of place next to real Win11 surfaces" impression.

| Before (12px) | After (14px) |
| --- | --- |
| <img width="280" height="414" alt="ramp-before-menu" src="https://github.com/user-attachments/assets/288b1392-06cd-48e5-87e0-840e08f21843" /> | <img width="280" height="422" alt="ramp-after-menu" src="https://github.com/user-attachments/assets/ea7012df-cc99-4455-b12f-c88f343e0726" /> |

| Before (13px body, 11-11.5px captions) | After (14px body, 12px captions) |
| --- | --- |
| <img width="1050" height="850" alt="ramp-before-settings" src="https://github.com/user-attachments/assets/dcf0f250-a716-4de1-85d7-91f588f25e43" /> | <img width="1050" height="850" alt="ramp-after-settings" src="https://github.com/user-attachments/assets/9f44f200-aaa9-4b67-8d90-b7dc5930d980" /> |
